### PR TITLE
fix(sampo-core): Fix workspace true dependencies handling

### DIFF
--- a/.sampo/changesets/regal-guardian-akka.md
+++ b/.sampo/changesets/regal-guardian-akka.md
@@ -1,0 +1,7 @@
+---
+packages:
+  - sampo-core
+release: patch
+---
+
+Fix `workspace = true` dependencies handling, whether for internal monorepo dependencies or monorepo-wide external dependencies.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1693,7 +1693,7 @@ checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "sampo"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "clap",
  "rand",
@@ -1708,7 +1708,7 @@ dependencies = [
 
 [[package]]
 name = "sampo-core"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "glob",
  "reqwest 0.12.23",
@@ -1723,7 +1723,7 @@ dependencies = [
 
 [[package]]
 name = "sampo-github-action"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "reqwest 0.12.23",
  "rustc-hash",


### PR DESCRIPTION
## What does this change?

* `crates/sampo-core/src/release.rs`: Updated `update_dependency_version` to skip updating dependencies marked with `workspace = true` + fixed formatting in `update_dependency_version` to avoid quoting dependency names.
* `crates/sampo-core/src/workspace.rs`: Updated `collect_internal_deps` and `is_internal_dep` so that only dependencies with `workspace = true` and whose names are actual workspace members are treated as internal. External workspace dependencies are no longer misclassified as internal.

## How is it tested?

* Added tests to `release.rs` to verify that workspace dependencies are skipped during updates and that simple dependencies are converted correctly.
* Added a test to `workspace.rs` to confirm that external workspace dependencies are not treated as internal.

## How is it documented?

N/A