### PR TITLE
feat: publish binaries

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,10 +20,7 @@ jobs:
         startsWith(github.event.pull_request.head.ref, 'release/') ||
         contains(github.event.pull_request.title, 'Release')
       )
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     environment: sampo
     steps:
       - uses: actions/checkout@v4
@@ -41,6 +38,7 @@ jobs:
           cargo-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
           create-github-release: true
           upload-binary: true
+          targets: x86_64-unknown-linux-gnu, x86_64-apple-darwin, x86_64-pc-windows-msvc
           open-discussion: true
           discussion-category: announcements
           use-local-build: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,7 +20,10 @@ jobs:
         startsWith(github.event.pull_request.head.ref, 'release/') ||
         contains(github.event.pull_request.title, 'Release')
       )
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     environment: sampo
     steps:
       - uses: actions/checkout@v4
@@ -37,6 +40,7 @@ jobs:
           command: post-merge-publish
           cargo-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
           create-github-release: true
+          upload-binary: true
           open-discussion: true
           discussion-category: announcements
           use-local-build: true

--- a/.sampo/changesets/doughty-count-ahti.md
+++ b/.sampo/changesets/doughty-count-ahti.md
@@ -1,0 +1,5 @@
+---
+sampo-github-action: minor
+---
+
+Sampo Github Action's Github Releases now include prebuilt binaries for CLI crates on Linux, macOS, and Windows. Enable with `create-github-release: true` and `upload-binary: true` (library-only crates are skipped automatically).

--- a/crates/sampo-github-action/README.md
+++ b/crates/sampo-github-action/README.md
@@ -101,10 +101,7 @@ jobs:
         startsWith(github.event.pull_request.head.ref, 'release/') ||
         contains(github.event.pull_request.title, 'Release')
       )
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:

--- a/crates/sampo-github-action/README.md
+++ b/crates/sampo-github-action/README.md
@@ -125,6 +125,8 @@ jobs:
           upload-binary: true
           # optional: specify binary name (defaults to crate name)
           binary-name: sampo
+          # optional: build and upload binaries for multiple targets in one run
+          # targets: x86_64-unknown-linux-gnu, x86_64-apple-darwin, x86_64-pc-windows-msvc
           # optional: pass flags to cargo publish
           args: --allow-dirty --no-verify
 ```
@@ -136,7 +138,9 @@ Notes:
 - Adjust the branch/title condition in the workflow if you customize the release PR branch name.
 - Ensure the workflow has `contents: write` (and `pull-requests: write` for prepare-pr) permissions. To open Discussions, also grant `discussions: write` and enable Discussions in the repository settings.
 - When `upload-binary` is enabled, the action uploads binaries only for crates that define a binary target (e.g., `src/main.rs`, `src/bin/*`, or `[[bin]]` in `Cargo.toml`). Pure library crates are skipped automatically.
- - For multi-platform binaries (Linux, macOS, Windows), run the `post-merge-publish` job on an OS matrix. Each job will reuse the same GitHub Release and upload its own asset named with the target triple.
+ - For multi-platform binaries (Linux, macOS, Windows), you have two options:
+   - Run the `post-merge-publish` job on an OS matrix so each runner builds its native binary.
+   - Or set `targets` to a list of Rust target triples to cross-compile in one job (requires those targets and linkers to be installed).
 
 ### Inputs
 
@@ -153,6 +157,7 @@ Notes:
 - `discussion-category`: preferred Discussions category slug (default preference: `announcements` when available)
 - `upload-binary`: if `true`, upload a binary asset when creating GitHub releases (only for crates with a binary target). The binary is built for the host runner target and the asset name includes the target triple.
 - `binary-name`: override binary name (defaults to the crate name or the single `[[bin]]` name when unambiguous)
+- `targets`: space- or comma-separated Rust target triples to build and upload (must already be installed via `rustup target add ...`). If omitted, only the host target is built.
 - `github-token`: GitHub token to create/update PRs (defaults to `GITHUB_TOKEN` env)
 
 ### Outputs

--- a/crates/sampo-github-action/action.yml
+++ b/crates/sampo-github-action/action.yml
@@ -47,6 +47,9 @@ inputs:
   binary-name:
     description: "Binary name to upload (defaults to the main package name)"
     required: false
+  targets:
+    description: "Space- or comma-separated Rust target triples to build and upload (must be installed). If empty, builds host only."
+    required: false
   github-token:
     description: "GitHub token to create/update PRs (defaults to GITHUB_TOKEN env)"
     required: false
@@ -83,6 +86,7 @@ runs:
         INPUT_DISCUSSION_CATEGORY: ${{ inputs['discussion-category'] }}
         INPUT_UPLOAD_BINARY: ${{ inputs['upload-binary'] }}
         INPUT_BINARY_NAME: ${{ inputs['binary-name'] }}
+        INPUT_TARGETS: ${{ inputs.targets }}
         INPUT_GITHUB_TOKEN: ${{ inputs['github-token'] }}
         INPUT_USE_LOCAL_BUILD: ${{ inputs['use-local-build'] }}
       run: |

--- a/crates/sampo-github-action/action.yml
+++ b/crates/sampo-github-action/action.yml
@@ -41,7 +41,7 @@ inputs:
     description: "Preferred Discussions category slug (default: 'announcements' if it exists)"
     required: false
   upload-binary:
-    description: "If true, upload Linux binary as release asset when creating GitHub releases"
+    description: "If true, upload binary as release asset when creating GitHub releases (only for binary crates)"
     required: false
     default: "false"
   binary-name:

--- a/crates/sampo-github-action/action.yml
+++ b/crates/sampo-github-action/action.yml
@@ -136,12 +136,6 @@ runs:
           cargo binstall --no-confirm sampo-github-action
         fi
 
-        # Install Linux cross-compilation target if upload-binary is enabled
-        if [[ "${INPUT_UPLOAD_BINARY:-}" == "true" || "${INPUT_UPLOAD_BINARY:-}" == "1" ]]; then
-          echo "Installing Linux cross-compilation target..."
-          rustup target add x86_64-unknown-linux-gnu
-        fi
-
         # Ensure git available (needed for tags and pushing)
         if ! command -v git >/dev/null 2>&1; then
           echo "Installing git..."


### PR DESCRIPTION
Fix #42 . Sampo Github Action's Github Releases now include prebuilt binaries for CLI crates on Linux, macOS, and Windows. Enable with `create-github-release: true` and `upload-binary: true` (library-only crates are skipped automatically).

## What does this change?

- `crates/sampo-github-action/src/github.rs`: build-and-upload function. 
- `crates/sampo-github-action/src/main.rs`: wired `github.rs`'s function into `post-merge-publish`. For each new tag we create or reuse the release, detect if the crate has a binary target (`src/main.rs`, `src/bin`, or `[[bin]]`), resolve its binary name, then build and upload the asset (only for binary crates).

## How is it tested?

N/A

## How is it documented?

On `sampo-github-action`'s README.