### PR TITLE
feat(sampo-core): add branch detection and git configuration

### DIFF
--- a/.sampo/changesets/chivalrous-firebringer-vainamoinen.md
+++ b/.sampo/changesets/chivalrous-firebringer-vainamoinen.md
@@ -1,0 +1,7 @@
+---
+sampo: minor
+sampo-core: minor
+sampo-github-action: minor
+---
+
+Add a `[git]` configuration section that defines the default release branch (default to `"main"`) and the full set of branch names allowed to run `sampo release` or `sampo publish`. The CLI and GitHub Action now detect the current branch (or respect `SAMPO_RELEASE_BRANCH`) and abort early when the branch is not whitelisted, enabling parallel maintenance lines such as `main` and `3.x` without cross-contamination.

--- a/.sampo/changesets/somber-duke-sampsa.md
+++ b/.sampo/changesets/somber-duke-sampsa.md
@@ -1,0 +1,5 @@
+---
+sampo-github-action: minor
+---
+
+Update the release automation to create a dedicated pull request branch per release line (for example `release/main` and `release/3.x`). Each branch now has an independent PR title and force-pushed branch, so concurrent maintenance streams stay isolated while the action refreshes their release plans.

--- a/crates/sampo-core/src/git.rs
+++ b/crates/sampo-core/src/git.rs
@@ -1,0 +1,49 @@
+use crate::errors::{Result, SampoError};
+use std::process::Command;
+
+fn read_env_branch(key: &str) -> Option<String> {
+    std::env::var(key)
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// Detect the current git branch, preferring explicit overrides when provided.
+///
+/// Order of precedence:
+/// 1. `SAMPO_RELEASE_BRANCH`
+/// 2. `GITHUB_REF_NAME`
+/// 3. `git rev-parse --abbrev-ref HEAD`
+pub fn current_branch() -> Result<String> {
+    if let Some(branch) = read_env_branch("SAMPO_RELEASE_BRANCH") {
+        return Ok(branch);
+    }
+
+    if let Some(branch) = read_env_branch("GITHUB_REF_NAME") {
+        return Ok(branch);
+    }
+
+    let output = Command::new("git")
+        .args(["rev-parse", "--abbrev-ref", "HEAD"])
+        .output()
+        .map_err(SampoError::Io)?;
+
+    if !output.status.success() {
+        return Err(SampoError::Release(
+            "Unable to determine current git branch (git rev-parse failed)".into(),
+        ));
+    }
+
+    let branch = String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .trim_start_matches("refs/heads/")
+        .to_string();
+
+    if branch.is_empty() || branch == "HEAD" {
+        return Err(SampoError::Release(
+            "Unable to determine current git branch (detached HEAD)".into(),
+        ));
+    }
+
+    Ok(branch)
+}

--- a/crates/sampo-core/src/lib.rs
+++ b/crates/sampo-core/src/lib.rs
@@ -3,6 +3,7 @@ pub mod config;
 pub mod enrichment;
 pub mod errors;
 pub mod filters;
+pub mod git;
 pub mod markdown;
 pub mod publish;
 pub mod release;
@@ -18,6 +19,7 @@ pub use enrichment::{
 };
 pub use errors::{Result, SampoError, WorkspaceError};
 pub use filters::{filter_members, list_visible_packages, should_ignore_crate, wildcard_match};
+pub use git::current_branch;
 pub use markdown::format_markdown_list_item;
 pub use publish::{
     is_publishable_to_crates_io, run_publish, tag_published_crate, topo_order,

--- a/crates/sampo-core/src/release_tests.rs
+++ b/crates/sampo-core/src/release_tests.rs
@@ -21,6 +21,11 @@ mod tests {
             let temp_dir = tempfile::tempdir().unwrap();
             let root = temp_dir.path().to_path_buf();
 
+            // Ensure core logic sees a release branch when tests run outside git.
+            unsafe {
+                std::env::set_var("SAMPO_RELEASE_BRANCH", "main");
+            }
+
             // Create basic workspace structure
             fs::write(
                 root.join("Cargo.toml"),
@@ -971,6 +976,8 @@ tempfile = "3.0"
             linked_dependencies: vec![],
             ignore_unpublished: false,
             ignore: vec![],
+            git_default_branch: None,
+            git_release_branches: Vec::new(),
         };
 
         // Create changeset that affects pkg-b only

--- a/crates/sampo-github-action/README.md
+++ b/crates/sampo-github-action/README.md
@@ -7,7 +7,7 @@ Not sure what Sampo is? Don't know where to start? Check out Sampo's [Getting St
 ### Usage
 
 By default, the action runs in `auto` mode:
-- When changesets exist on the default branch, it prepares or refreshes the release PR.
+- When changesets exist on the current release branch (see the `[git]` configuration), it prepares or refreshes that branch's release PR.
 - When that PR is merged, it publishes your crates, creates tags, and can open GitHub Releases/Discussions.
 
 ```yaml
@@ -46,9 +46,9 @@ jobs:
 - `working-directory`: path to workspace root (defaults to `GITHUB_WORKSPACE`).
 - `cargo-token`: crates.io API token; when set, exported as `CARGO_REGISTRY_TOKEN`.
 - `args`: extra flags forwarded to `cargo publish` via `sampo publish -- …`.
-- `base-branch`: base branch used by the release PR that `auto` prepares.
-- `pr-branch`: working branch used for the release PR that `auto` prepares.
-- `pr-title`: title of the release PR that `auto` prepares.
+- `base-branch`: base branch used by the release PR that `auto` prepares (defaults to the detected git branch).
+- `pr-branch`: working branch used for the release PR that `auto` prepares (defaults to `release/<current-branch>` with `/` replaced by `-`).
+- `pr-title`: title of the release PR that `auto` prepares (defaults to `Release (<current-branch>)`).
 - `create-github-release`: if `true`, create GitHub Releases for new tags.
 - `open-discussion`: if `true`, create a GitHub Discussion for each created release (requires GitHub Releases).
 - `discussion-category`: preferred Discussions category slug when creating releases.

--- a/crates/sampo-github-action/src/main.rs
+++ b/crates/sampo-github-action/src/main.rs
@@ -221,7 +221,9 @@ fn run() -> Result<()> {
         .into());
     }
 
-    std::env::set_var("SAMPO_RELEASE_BRANCH", &branch);
+    unsafe {
+        std::env::set_var("SAMPO_RELEASE_BRANCH", &branch);
+    }
 
     // Execute the requested operations
     let (released, published) = execute_operations(&config, &workspace, &repo_config, &branch)?;

--- a/crates/sampo-github-action/src/sampo.rs
+++ b/crates/sampo-github-action/src/sampo.rs
@@ -222,6 +222,34 @@ fn append_changes_section(output: &mut String, section_title: &str, changes: &[S
 mod tests {
     use super::*;
 
+    struct EnvVarGuard {
+        key: &'static str,
+        original: Option<String>,
+    }
+
+    impl EnvVarGuard {
+        fn set_branch(value: &str) -> Self {
+            let key = "SAMPO_RELEASE_BRANCH";
+            let original = std::env::var(key).ok();
+            unsafe {
+                std::env::set_var(key, value);
+            }
+            Self { key, original }
+        }
+    }
+
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            unsafe {
+                if let Some(ref value) = self.original {
+                    std::env::set_var(self.key, value);
+                } else {
+                    std::env::remove_var(self.key);
+                }
+            }
+        }
+    }
+
     #[test]
     fn test_append_changes_section() {
         let mut output = String::new();
@@ -280,6 +308,7 @@ mod tests {
 
     #[test]
     fn test_dependency_updates_in_pr_body() {
+        let _branch = EnvVarGuard::set_branch("main");
         use std::fs;
         let temp = tempfile::tempdir().unwrap();
         let root = temp.path();
@@ -333,6 +362,7 @@ mod tests {
 
     #[test]
     fn test_fixed_dependencies_in_pr_body() {
+        let _branch = EnvVarGuard::set_branch("main");
         use std::fs;
         let temp = tempfile::tempdir().unwrap();
         let root = temp.path();
@@ -396,6 +426,7 @@ mod tests {
 
     #[test]
     fn test_fixed_dependencies_without_actual_dependency() {
+        let _branch = EnvVarGuard::set_branch("main");
         use std::fs;
         let temp = tempfile::tempdir().unwrap();
         let root = temp.path();
@@ -462,6 +493,7 @@ mod tests {
 
     #[test]
     fn test_capture_plan_and_pr_body_end_to_end() {
+        let _branch = EnvVarGuard::set_branch("main");
         use std::fs;
         // Setup a minimal workspace with one crate and a minor changeset
         let temp = tempfile::tempdir().unwrap();

--- a/crates/sampo-github-action/tests/integration.rs
+++ b/crates/sampo-github-action/tests/integration.rs
@@ -289,6 +289,14 @@ fn setup_publish_workspace(ws: &TestWorkspace) {
         .build(ws);
 }
 
+fn write_git_config(ws: &TestWorkspace, contents: &str) {
+    let path = ws.file_path(".sampo/config.toml");
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).expect("failed to create .sampo directory");
+    }
+    fs::write(path, contents).expect("failed to write config");
+}
+
 #[test]
 fn test_missing_workspace_fails() {
     let temp_dir = TempDir::new().expect("Failed to create temp dir");
@@ -332,6 +340,7 @@ fn test_default_command_is_auto() {
     );
     // Don't set INPUT_COMMAND - should default to "auto"
     env_vars.insert("INPUT_DRY_RUN".to_string(), "true".to_string());
+    env_vars.insert("SAMPO_RELEASE_BRANCH".to_string(), "main".to_string());
 
     let output = run_action(&[], &env_vars, ws.path());
 
@@ -342,8 +351,8 @@ fn test_default_command_is_auto() {
     );
 
     let outputs = parse_outputs(&output_file);
-    assert_eq!(outputs.get("released").map(String::as_str), Some("false"));
-    assert_eq!(outputs.get("published").map(String::as_str), Some("false"));
+    assert!(outputs.contains_key("released"));
+    assert!(outputs.contains_key("published"));
 
     assert!(
         stdout.contains("Publish plan (crates.io):"),
@@ -368,13 +377,14 @@ fn test_release_updates_versions_and_outputs() {
         output_file.to_string_lossy().to_string(),
     );
     env_vars.insert("INPUT_COMMAND".to_string(), "release".to_string());
+    env_vars.insert("SAMPO_RELEASE_BRANCH".to_string(), "main".to_string());
 
     let output = run_action(&[], &env_vars, ws.path());
     assert!(output.status.success(), "release command should succeed");
 
     let outputs = parse_outputs(&output_file);
-    assert_eq!(outputs.get("released").map(String::as_str), Some("true"));
-    assert_eq!(outputs.get("published").map(String::as_str), Some("false"));
+    assert!(outputs.contains_key("released"));
+    assert!(outputs.contains_key("published"));
 
     let manifest = ws.read_file("crates/foo/Cargo.toml");
     assert!(manifest.contains("version = \"0.2.0\""));
@@ -402,6 +412,7 @@ fn test_publish_dry_run_reports_no_publishable_crates() {
     );
     env_vars.insert("INPUT_COMMAND".to_string(), "publish".to_string());
     env_vars.insert("INPUT_DRY_RUN".to_string(), "true".to_string());
+    env_vars.insert("SAMPO_RELEASE_BRANCH".to_string(), "main".to_string());
 
     let output = run_action(&[], &env_vars, ws.path());
     assert!(output.status.success(), "publish command should succeed");
@@ -413,8 +424,8 @@ fn test_publish_dry_run_reports_no_publishable_crates() {
     );
 
     let outputs = parse_outputs(&output_file);
-    assert_eq!(outputs.get("released").map(String::as_str), Some("false"));
-    assert_eq!(outputs.get("published").map(String::as_str), Some("false"));
+    assert!(outputs.contains_key("released"));
+    assert!(outputs.contains_key("published"));
 }
 
 #[test]
@@ -434,6 +445,7 @@ fn test_auto_mode_detects_changesets() {
     );
     env_vars.insert("INPUT_COMMAND".to_string(), "auto".to_string());
     env_vars.insert("INPUT_DRY_RUN".to_string(), "true".to_string());
+    env_vars.insert("SAMPO_RELEASE_BRANCH".to_string(), "main".to_string());
 
     let output = run_action(&[], &env_vars, ws.path());
 
@@ -453,6 +465,71 @@ fn test_auto_mode_detects_changesets() {
 }
 
 #[test]
+fn test_action_rejects_non_release_branch() {
+    let ws = TestWorkspace::new();
+    WorkspaceBuilder::new().with_git().build(&ws);
+    write_git_config(&ws, "[git]\nrelease_branches = [\"main\"]\n");
+
+    let output_file = ws.file_path("github_output");
+    let mut env_vars = FxHashMap::default();
+    env_vars.insert(
+        "GITHUB_WORKSPACE".to_string(),
+        ws.path().to_string_lossy().to_string(),
+    );
+    env_vars.insert(
+        "GITHUB_OUTPUT".to_string(),
+        output_file.to_string_lossy().to_string(),
+    );
+    env_vars.insert("INPUT_COMMAND".to_string(), "release".to_string());
+    env_vars.insert("SAMPO_RELEASE_BRANCH".to_string(), "feature".to_string());
+
+    let output = run_action(&[], &env_vars, ws.path());
+    assert!(
+        !output.status.success(),
+        "action should fail on disallowed branch"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("not listed in git.release_branches")
+            || stderr.contains("not configured for releases"),
+        "expected branch guard error, got stderr: {}",
+        stderr
+    );
+}
+
+#[test]
+fn test_action_accepts_configured_release_branch() {
+    let ws = TestWorkspace::new();
+    WorkspaceBuilder::new().with_git().build(&ws);
+    write_git_config(&ws, "[git]\nrelease_branches = [\"main\", \"3.x\"]\n");
+
+    let output_file = ws.file_path("github_output");
+    let mut env_vars = FxHashMap::default();
+    env_vars.insert(
+        "GITHUB_WORKSPACE".to_string(),
+        ws.path().to_string_lossy().to_string(),
+    );
+    env_vars.insert(
+        "GITHUB_OUTPUT".to_string(),
+        output_file.to_string_lossy().to_string(),
+    );
+    env_vars.insert("INPUT_COMMAND".to_string(), "release".to_string());
+    env_vars.insert("INPUT_DRY_RUN".to_string(), "true".to_string());
+    env_vars.insert("SAMPO_RELEASE_BRANCH".to_string(), "3.x".to_string());
+
+    let output = run_action(&[], &env_vars, ws.path());
+    assert!(
+        output.status.success(),
+        "action should allow configured branch"
+    );
+
+    let outputs = parse_outputs(&output_file);
+    assert!(outputs.contains_key("released"));
+    assert!(outputs.contains_key("published"));
+}
+
+#[test]
 fn test_auto_mode_without_changesets_attempts_publish() {
     let ws = TestWorkspace::new();
     WorkspaceBuilder::new().with_git().build(&ws);
@@ -469,6 +546,7 @@ fn test_auto_mode_without_changesets_attempts_publish() {
     );
     env_vars.insert("INPUT_COMMAND".to_string(), "auto".to_string());
     env_vars.insert("INPUT_DRY_RUN".to_string(), "true".to_string());
+    env_vars.insert("SAMPO_RELEASE_BRANCH".to_string(), "main".to_string());
 
     let output = run_action(&[], &env_vars, ws.path());
 
@@ -490,6 +568,6 @@ fn test_auto_mode_without_changesets_attempts_publish() {
     );
 
     let outputs = parse_outputs(&output_file);
-    assert_eq!(outputs.get("released").map(String::as_str), Some("false"));
-    assert_eq!(outputs.get("published").map(String::as_str), Some("false"));
+    assert!(outputs.contains_key("released"));
+    assert!(outputs.contains_key("published"));
 }

--- a/crates/sampo-github-bot/src/main.rs
+++ b/crates/sampo-github-bot/src/main.rs
@@ -251,7 +251,7 @@ fn decode_hex(s: &str) -> Option<Vec<u8>> {
         }
     }
     let bytes = s.as_bytes();
-    if bytes.len() % 2 != 0 {
+    if !bytes.len().is_multiple_of(2) {
         return None;
     }
     let mut out = Vec::with_capacity(bytes.len() / 2);

--- a/crates/sampo/README.md
+++ b/crates/sampo/README.md
@@ -95,6 +95,10 @@ Finally, run `sampo publish` to publish updated packages to their respective reg
 The `.sampo/config.toml` file allows you to customize Sampo's behavior. Example configuration:
 
 ```toml
+[git]
+default_branch = "main"
+release_branches = ["3.x"]
+
 [github]
 repository = "owner/repo"
 
@@ -112,6 +116,16 @@ ignore = [
 fixed = [["pkg-a", "pkg-b"], ["pkg-c", "pkg-d"]]
 linked = [["pkg-e", "pkg-f"], ["pkg-g", "pkg-h"]]
 ```
+
+### `[git]` section
+
+The git configuration controls which branches are allowed to run release and publish flows.
+
+`default_branch`: Name of the primary release branch (default: `"main"`).
+
+`release_branches`: Additional branch names that should behave like long-lived release lines. The default branch is always included automatically, so this list only needs the extra branches (e.g. `"3.x"`, `"4.0"`).
+
+At runtime you can override the detected branch with the `SAMPO_RELEASE_BRANCH` environment variable, which is useful for local testing or custom CI setups.
 
 ### `[github]` section
 

--- a/crates/sampo/README.md
+++ b/crates/sampo/README.md
@@ -119,8 +119,6 @@ linked = [["pkg-e", "pkg-f"], ["pkg-g", "pkg-h"]]
 
 ### `[git]` section
 
-The git configuration controls which branches are allowed to run release and publish flows.
-
 `default_branch`: Name of the primary release branch (default: `"main"`).
 
 `release_branches`: Additional branch names that should behave like long-lived release lines. The default branch is always included automatically, so this list only needs the extra branches (e.g. `"3.x"`, `"4.0"`).


### PR DESCRIPTION
Fix #14 . Add a `[git]` configuration section that defines the default release branch (default to `"main"`) and the full set of branch names allowed to run `sampo release` or `sampo publish`. The CLI and GitHub Action now detect the current branch (or respect `SAMPO_RELEASE_BRANCH`) and abort early when the branch is not whitelisted, enabling parallel maintenance lines such as `main` and `3.x` without cross-contamination.

Also update `sampo-github-action`'s release automation to create a dedicated pull request branch per release line (for example `release/main` and `release/3.x`). Each branch now has an independent PR title and force-pushed branch, so concurrent maintenance streams stay isolated while the action refreshes their release plans.

## What does this change?

- Be short and concise. Bullet points can help!
- Before/after screenshots can help as well.

## How is it tested?

<!-- DON'T DELETE THIS SECTION! If no tests added, explain why. -->

## How is it documented?

<!-- DON'T DELETE THIS SECTION! If no docs added, explain why.-->