### PR TITLE
feat(github-action): stabilize PR automation

### DIFF
--- a/.sampo/changesets/chivalrous-queen-tuoni.md
+++ b/.sampo/changesets/chivalrous-queen-tuoni.md
@@ -1,7 +1,7 @@
 ---
-sampo: minor
-sampo-core: minor
-sampo-github-action: minor
+sampo: patch
+sampo-core: patch
+sampo-github-action: patch
 ---
 
 When updating changelogs, Sampo now preserves any intro content or custom main header before the first `##` section. You can also manually edit previously released entries, and Sampo will keep them intact.

--- a/.sampo/changesets/resolute-sage-lemminkainen.md
+++ b/.sampo/changesets/resolute-sage-lemminkainen.md
@@ -1,0 +1,5 @@
+---
+sampo-github-action: minor
+---
+
+Add automatic stabilize PR support: when a release plan targets pre-release versions the action now prepares a companion PR that exits pre-release mode, consumes preserved changesets, and readies the stable release branch.

--- a/crates/sampo-github-action/README.md
+++ b/crates/sampo-github-action/README.md
@@ -8,6 +8,7 @@ Not sure what Sampo is? Don't know where to start? Check out Sampo's [Getting St
 
 By default, the action runs in `auto` mode:
 - When changesets exist on the current release branch (see the `[git]` configuration), it prepares or refreshes that branch's release PR.
+- When the release plan targets pre-release versions, it also prepares a stabilize PR that exits pre-release mode and lines up the stable release for the same set of changesets.
 - When that PR is merged, it publishes your crates, creates tags, and can open GitHub Releases/Discussions. Can also mark Github Releases as « pre-release » for pre-releases branches.
 
 ```yaml
@@ -49,6 +50,8 @@ jobs:
 - `base-branch`: base branch used by the release PR that `auto` prepares (defaults to the detected git branch).
 - `pr-branch`: working branch used for the release PR that `auto` prepares (defaults to `release/<current-branch>` with `/` replaced by `-`).
 - `pr-title`: title of the release PR that `auto` prepares (defaults to `Release (<current-branch>)`).
+- `stabilize-pr-branch`: working branch used for the stabilize PR that `auto` prepares (defaults to `stabilize/<current-branch>` with `/` replaced by `-`).
+- `stabilize-pr-title`: title of the stabilize PR that `auto` prepares (defaults to `Release stable (<current-branch>)`).
 - `create-github-release`: if `true`, create GitHub Releases for new tags.
 - `open-discussion`: if `true`, create a GitHub Discussion for each created release (requires GitHub Releases).
 - `discussion-category`: preferred Discussions category slug when creating releases.
@@ -60,7 +63,7 @@ jobs:
 
 ### Outputs
 
-- `released`: `"true"` when release automation ran (release PR prepared or `sampo release` executed).
+- `released`: `"true"` when release automation ran (release PR prepared, stabilize PR prepared, or `sampo release` executed).
 - `published`: `"true"` when new tags were pushed (i.e. crates were published in non-dry runs).
 
 Can be used to gate subsequent steps, example:

--- a/crates/sampo-github-action/action.yml
+++ b/crates/sampo-github-action/action.yml
@@ -29,6 +29,12 @@ inputs:
   pr-title:
     description: "Title for the Release PR when auto prepares it"
     required: false
+  stabilize-pr-branch:
+    description: "Branch name for the Stabilize PR when auto prepares it"
+    required: false
+  stabilize-pr-title:
+    description: "Title for the Stabilize PR when auto prepares it"
+    required: false
   create-github-release:
     description: "If true, create GitHub releases for new tags when publishing"
     required: false
@@ -81,6 +87,8 @@ runs:
         INPUT_BASE_BRANCH: ${{ inputs['base-branch'] }}
         INPUT_PR_BRANCH: ${{ inputs['pr-branch'] }}
         INPUT_PR_TITLE: ${{ inputs['pr-title'] }}
+        INPUT_STABILIZE_PR_BRANCH: ${{ inputs['stabilize-pr-branch'] }}
+        INPUT_STABILIZE_PR_TITLE: ${{ inputs['stabilize-pr-title'] }}
         INPUT_CREATE_GITHUB_RELEASE: ${{ inputs['create-github-release'] }}
         INPUT_OPEN_DISCUSSION: ${{ inputs['open-discussion'] }}
         INPUT_DISCUSSION_CATEGORY: ${{ inputs['discussion-category'] }}

--- a/crates/sampo-github-action/src/sampo.rs
+++ b/crates/sampo-github-action/src/sampo.rs
@@ -1,8 +1,9 @@
 use crate::error::{ActionError, Result};
 use sampo_core::format_markdown_list_item;
 use sampo_core::{
-    Bump, Config, detect_all_dependency_explanations, detect_github_repo_slug_with_config,
-    discover_workspace, enrich_changeset_message, get_commit_hash_for_path, load_changesets,
+    Bump, Config, VersionChange, detect_all_dependency_explanations,
+    detect_github_repo_slug_with_config, discover_workspace, enrich_changeset_message,
+    exit_prerelease as core_exit_prerelease, get_commit_hash_for_path, load_changesets,
     run_publish as core_publish, run_release as core_release,
 };
 use std::collections::BTreeMap;
@@ -82,6 +83,14 @@ pub fn run_publish(
     })?;
 
     Ok(())
+}
+
+/// Exit pre-release mode for the provided packages.
+pub fn exit_prerelease(workspace: &Path, packages: &[String]) -> Result<Vec<VersionChange>> {
+    core_exit_prerelease(workspace, packages).map_err(|e| ActionError::SampoCommandFailed {
+        operation: "exit-prerelease".to_string(),
+        message: format!("sampo pre exit failed: {}", e),
+    })
 }
 
 /// Compute a markdown PR body summarizing the pending release by crate,


### PR DESCRIPTION
Fix #73 . Add automatic stabilize PR support: when a release plan targets pre-release versions the action now prepares a companion PR that exits pre-release mode, consumes preserved changesets, and readies the stable release branch.

## What does this change?

- `crates/sampo-github-action/src/main.rs`: now wires the auto flow to create both release and stabilize PR branches, adds pre-release detection helpers, and keeps the workspace clean by resetting branches after each step.
- `crates/sampo-github-action/src/sampo.rs`: exposes a safe `exit_prerelease` wrapper so the action can reuse the core logic when preparing the stabilize PR.
- `crates/sampo-github-action/action.yml`: add the new `stabilize-pr-branch` and `stabilize-pr-title` inputs.

## How is it tested?

- `crates/sampo-github-action/src/main.rs`: `collect_prerelease_packages_detects_members` ensures the helper only flags workspace members whose `Cargo.toml` version includes a pre-release suffix.

## How is it documented?

- `crates/sampo-github-action/README.md`: updated with the new inputs and outputs, plus a little phrase about the stabilize PRs.