### PR TITLE
feat(core): restore changesets when switching pre-release

### DIFF
--- a/.sampo/changesets/dashing-duke-tuoni.md
+++ b/.sampo/changesets/dashing-duke-tuoni.md
@@ -1,0 +1,7 @@
+---
+sampo: minor
+sampo-core: minor
+sampo-github-action: minor
+---
+
+While in pre-release mode, you can continue to add changesets and run `sampo release` and `sampo publish` as usual, Sampo preserves the consumed changesets in `.sampo/prerelease/`. When exiting pre-release mode or switching to a different label (for example, from `alpha` to `beta`), any preserved changesets are restored back to `.sampo/changesets/`, so the next release keeps the full history.

--- a/crates/sampo-core/src/lib.rs
+++ b/crates/sampo-core/src/lib.rs
@@ -22,7 +22,9 @@ pub use errors::{Result, SampoError, WorkspaceError};
 pub use filters::{filter_members, list_visible_packages, should_ignore_crate, wildcard_match};
 pub use git::current_branch;
 pub use markdown::format_markdown_list_item;
-pub use prerelease::{VersionChange, enter_prerelease, exit_prerelease};
+pub use prerelease::{
+    VersionChange, enter_prerelease, exit_prerelease, restore_preserved_changesets,
+};
 pub use publish::{
     is_publishable_to_crates_io, run_publish, tag_published_crate, topo_order,
     version_exists_on_crates_io,

--- a/crates/sampo-core/src/release.rs
+++ b/crates/sampo-core/src/release.rs
@@ -525,7 +525,10 @@ fn releases_include_prerelease(releases: &ReleasePlan) -> bool {
     })
 }
 
-fn restore_prerelease_changesets(prerelease_dir: &Path, changesets_dir: &Path) -> Result<()> {
+pub(crate) fn restore_prerelease_changesets(
+    prerelease_dir: &Path,
+    changesets_dir: &Path,
+) -> Result<()> {
     if !prerelease_dir.exists() {
         return Ok(());
     }
@@ -578,7 +581,7 @@ fn finalize_consumed_changesets(
     Ok(())
 }
 
-fn move_changeset_file(source: &Path, dest_dir: &Path) -> Result<PathBuf> {
+pub(crate) fn move_changeset_file(source: &Path, dest_dir: &Path) -> Result<PathBuf> {
     if !source.exists() {
         return Ok(source.to_path_buf());
     }

--- a/crates/sampo/README.md
+++ b/crates/sampo/README.md
@@ -53,8 +53,6 @@ A helpful description of the change, to be read by your users.
 
 Pending changesets are stored in the `.sampo/changesets` directory.
 
-When you cut pre-release versions (alpha, beta, rc), Sampo preserves the consumed files by moving them into `.sampo/prerelease/`; they are automatically restored for the eventual stable release.
-
 #### Changelog
 
 At the root of each published package, a human-readable file listing all changes for each released version. Example:
@@ -101,9 +99,7 @@ Finally, run `sampo publish` to publish updated packages to their respective reg
 
 Run `sampo pre` to manage pre-release versions for one or more packages.
 
-While in pre-release mode, you can continue to add changesets and run `sampo release` and `sampo publish` as usual. Sampo preserves the consumed changesets in `.sampo/prerelease/`. When exiting pre-release mode, any preserved changesets are restored back to `.sampo/changesets/`, so they can be consumed in the next stable release.
-
-You can switch between different pre-release labels (for example, from `alpha` to `beta`) at any time without losing changesets.
+While in pre-release mode, you can continue to add changesets and run `sampo release` and `sampo publish` as usual, Sampo preserves the consumed changesets in `.sampo/prerelease/`. When exiting pre-release mode or switching to a different label (for example, from `alpha` to `beta`), any preserved changesets are restored back to `.sampo/changesets/`, so the next release keeps the full history.
 
 ## Configuration
 


### PR DESCRIPTION
Fix #72 . When switching to a different pre-release label (for example, from `alpha` to `beta`), any preserved changesets are restored back to `.sampo/changesets/`, so the next release keeps the full history.

## What does this change?

- `crates/sampo-core/src/prerelease.rs`: added and exposed `restore_preserved_changesets`, and wired it to the existing mover in `crates/sampo-core/src/release.rs`.
- `crates/sampo/src/prerelease.rs`: updated CLI flow to detect non-numeric base label changes, run `exit_prerelease`, and restore preserved changesets only for switched packages, before re-entering.

## How is it tested?

Unit tests in `crates/sampo-core/src/prerelease.rs` and integration tests in `crates/sampo-core/src/release_tests.rs`.

## How is it documented?

- `crates/sampo/README.md`: now clearly explain how changelogs are preserved and restored, both for exiting pre-release mode or switching to a different label.