### PR TITLE
fix(github-action): release use first heading 2

### DIFF
--- a/.sampo/changesets/cranky-duchess-vellamo.md
+++ b/.sampo/changesets/cranky-duchess-vellamo.md
@@ -1,0 +1,5 @@
+---
+sampo-github-action: patch
+---
+
+Fix GitHub Release bodies not being correctly filled when changelogs include release timestamps in their headings.


### PR DESCRIPTION
#83 . Fix GitHub Release bodies not being correctly filled when changelogs include release timestamps in their headings.

## What does this change?

- `crates/sampo-github-action/src/main.rs`: `extract_changelog_section` used to parse headings to find the right version, but it doesn't work anymore with release timestamps... now only takes the first `##` section, since it's always the new version.

## How is it tested?

- `crates/sampo-github-action/src/main.rs`: tests with and without timestamp in headings.

## How is it documented?

Expected behaviour.