### PR TITLE
feat(github-action): use pre-built release assets for GitHub uploads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,44 @@ permissions:
   discussions: write
 
 jobs:
+  build-artifacts:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+            binary: sampo
+          - os: macos-latest
+            target: x86_64-apple-darwin
+            binary: sampo
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            binary: sampo.exe
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Build release binary
+        shell: bash
+        run: |
+          set -euo pipefail
+          cargo build --release --bin sampo
+          mkdir -p dist/tmp
+          cp "target/release/${{ matrix.binary }}" "dist/tmp/${{ matrix.binary }}"
+          tar -C dist/tmp -czf "dist/sampo-${{ matrix.target }}.tar.gz" "${{ matrix.binary }}"
+          rm -rf dist/tmp
+
+      - name: Upload release binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: sampo-${{ matrix.target }}
+          path: dist/sampo-${{ matrix.target }}.tar.gz
+
   release:
+    needs: build-artifacts
     runs-on: ubuntu-latest
     environment: sampo
     steps:
@@ -20,8 +57,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install Rust targets for binary releases
-        run: rustup target add x86_64-apple-darwin x86_64-pc-windows-msvc
+      - name: Download release binaries
+        uses: actions/download-artifact@v4
+        with:
+          pattern: sampo-*
+          merge-multiple: true
+          path: dist
 
       - name: Run Sampo to release & publish
         id: sampo
@@ -30,8 +71,10 @@ jobs:
           command: auto
           cargo-token: ${{ secrets.CARGO_REGISTRY_TOKEN }}
           create-github-release: true
-          upload-binary: true
-          targets: x86_64-unknown-linux-gnu, x86_64-apple-darwin, x86_64-pc-windows-msvc
+          release-assets: |
+            dist/sampo-x86_64-unknown-linux-gnu.tar.gz => sampo-{{tag}}-x86_64-unknown-linux-gnu.tar.gz
+            dist/sampo-x86_64-apple-darwin.tar.gz => sampo-{{tag}}-x86_64-apple-darwin.tar.gz
+            dist/sampo-x86_64-pc-windows-msvc.tar.gz => sampo-{{tag}}-x86_64-pc-windows-msvc.tar.gz
           open-discussion: true
           discussion-category: announcements
           use-local-build: true

--- a/.sampo/changesets/resolute-runesmith-vipunen.md
+++ b/.sampo/changesets/resolute-runesmith-vipunen.md
@@ -1,0 +1,31 @@
+---
+sampo-github-action: minor
+---
+
+**⚠️ breaking change:** Drop the built-in binary build/upload flags in favor of a simple new `release-assets` input. Workflows should now provide pre-built artifacts (paths or glob patterns, with optional renames and templated placeholders) that the action uploads after publishing.
+
+```diff
+      - name: Install Rust targets for cross-compilation
+        run: rustup target add x86_64-apple-darwin x86_64-pc-windows-msvc
+
++      - name: Build binaries
++        run: |
++          cargo build --release --target x86_64-unknown-linux-gnu
++          cargo build --release --target x86_64-apple-darwin
++          cargo build --release --target x86_64-pc-windows-msvc
++          mkdir -p dist
++          tar -C target/x86_64-unknown-linux-gnu/release -czf dist/my-cli-x86_64-unknown-linux-gnu.tar.gz my-cli
++          tar -C target/x86_64-apple-darwin/release -czf dist/my-cli-x86_64-apple-darwin.tar.gz my-cli
++          zip -j dist/my-cli-x86_64-pc-windows-msvc.zip target/x86_64-pc-windows-msvc/release/my-cli.exe
+
+      - name: Run Sampo to release & publish
+        uses: bruits/sampo/crates/sampo-github-action@main
+        with:
+          create-github-release: true
+-          upload-binary: true
+-          targets: x86_64-unknown-linux-gnu, x86_64-apple-darwin, x86_64-pc-windows-msvc
++          release-assets: |
++            dist/my-cli-x86_64-unknown-linux-gnu.tar.gz => my-cli-{{tag}}-x86_64-unknown-linux-gnu.tar.gz
++            dist/my-cli-x86_64-apple-darwin.tar.gz => my-cli-{{tag}}-x86_64-apple-darwin.tar.gz
++            dist/my-cli-x86_64-pc-windows-msvc.zip => my-cli-{{tag}}-x86_64-pc-windows-msvc.zip
+```

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1878,6 +1878,7 @@ dependencies = [
 name = "sampo-github-action"
 version = "0.8.1"
 dependencies = [
+ "glob",
  "reqwest 0.12.23",
  "rustc-hash",
  "sampo-core",
@@ -1886,7 +1887,6 @@ dependencies = [
  "serde_json",
  "tempfile",
  "thiserror 1.0.69",
- "toml",
 ]
 
 [[package]]

--- a/crates/sampo-github-action/Cargo.toml
+++ b/crates/sampo-github-action/Cargo.toml
@@ -14,7 +14,7 @@ categories = ["development-tools"]
 [dependencies]
 sampo-core = { version = "0.6.0", path = "../sampo-core" }
 thiserror = "1.0"
-toml = "0.8"
+glob = "0.3"
 rustc-hash = "2.0"
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }

--- a/crates/sampo-github-action/README.md
+++ b/crates/sampo-github-action/README.md
@@ -1,10 +1,12 @@
-## Sampo's GitHub Action
+# Sampo's GitHub Action
 
 GitHub Action to run Sampo (release and/or publish) in GitHub Actions.
 
 Not sure what Sampo is? Don't know where to start? Check out Sampo's [Getting Started](./crates/sampo/README.md#getting-started) guide.
 
-### Usage
+## Usages
+
+### Release and Publish
 
 By default, the action runs in `auto` mode:
 - When changesets exist on the current release branch (see the `[git]` configuration), it prepares or refreshes that branch's release PR.
@@ -34,39 +36,46 @@ jobs:
         id: sampo
         uses: bruits/sampo/crates/sampo-github-action@main
         with:
-          # Read the "Inputs" section below for details on these options
+          # Options here, see below
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_TOKEN: ${{ secrets.CARGO_TOKEN }} # Only needed to publish to crates.io
 ```
 
-### Inputs
+### Creating GitHub Releases and Discussions
 
-- `command`: `auto`, `release`, or `publish` (default: `auto`).
-- `dry-run`: if `true`, simulates changes without writing or publishing (default: `false`).
-- `working-directory`: path to workspace root (defaults to `GITHUB_WORKSPACE`).
-- `cargo-token`: crates.io API token; when set, exported as `CARGO_REGISTRY_TOKEN`.
-- `args`: extra flags forwarded to `cargo publish` via `sampo publish -- …`.
-- `base-branch`: base branch used by the release PR that `auto` prepares (defaults to the detected git branch).
-- `pr-branch`: working branch used for the release PR that `auto` prepares (defaults to `release/<current-branch>` with `/` replaced by `-`).
-- `pr-title`: title of the release PR that `auto` prepares (defaults to `Release (<current-branch>)`).
-- `stabilize-pr-branch`: working branch used for the stabilize PR that `auto` prepares (defaults to `stabilize/<current-branch>` with `/` replaced by `-`).
-- `stabilize-pr-title`: title of the stabilize PR that `auto` prepares (defaults to `Release stable (<current-branch>)`).
-- `create-github-release`: if `true`, create GitHub Releases for new tags.
-- `open-discussion`: if `true`, create a GitHub Discussion for each created release (requires GitHub Releases).
-- `discussion-category`: preferred Discussions category slug when creating releases.
-- `upload-binary`: if `true`, upload a binary asset when creating GitHub releases (only for crates with a binary target).
-- `binary-name`: override binary name (defaults to the crate name or the single `[[bin]]` name when unambiguous).
-- `targets`: space- or comma-separated Rust target triples to build and upload (must be installed); default builds the host target only.
-- `github-token`: GitHub token to create/update PRs (defaults to `GITHUB_TOKEN` env).
-- `use-local-build`: if `true`, compile the local `sampo-github-action` binary instead of installing it with `cargo-binstall`.
+Set the `create-github-release` input to `true` to create a GitHub Release for each new tag created when publishing crates. The release notes are generated from the changesets included in the release.
 
-### Outputs
+If you also set `open-discussion` to `true`, a GitHub Discussion will be created for each release, in the category specified by `discussion-category` (if provided) or the repository's default category.
+
+### Uploading release assets in GitHub Releases
+
+Build binaries or archives in earlier workflow steps, then pass their paths or glob patterns through the `release-assets` input for upload. Patterns are resolved relative to `working-directory` unless absolute.
+
+- Separate multiple entries with commas or new lines.
+- Use `=>` to rename matches (for example `dist/*.zip => my-tool.zip`).
+- The placeholders `{{tag}}`, `{{crate}}`, and `{{version}}` expand from the tag being published.
+
+Example:
+
+```yaml
+      - run: cargo build --release
+      - uses: bruits/sampo/crates/sampo-github-action@main
+        with:
+          create-github-release: true
+          release-assets: |
+            target/release/my-cli => my-cli-{{tag}}
+            dist/{{crate}}-v{{version}}-*.tar.gz
+```
+
+### Using outputs to conditionally run steps
+
+The action exposes two outputs:
 
 - `released`: `"true"` when release automation ran (release PR prepared, stabilize PR prepared, or `sampo release` executed).
 - `published`: `"true"` when new tags were pushed (i.e. crates were published in non-dry runs).
 
-Can be used to gate subsequent steps, example:
+These outputs can be used to gate subsequent steps, example:
 
 ```yaml
       - name: Create release PR or publish packages
@@ -83,6 +92,27 @@ Can be used to gate subsequent steps, example:
         if: steps.sampo.outputs.published == 'true'
         run: echo "Crates were published"
 ```
+
+## Configuration
+
+The action supports the following inputs:
+
+- `command`: `auto`, `release`, or `publish` (default: `auto`).
+- `dry-run`: if `true`, simulates changes without writing or publishing (default: `false`).
+- `working-directory`: path to workspace root (defaults to `GITHUB_WORKSPACE`).
+- `cargo-token`: crates.io API token; when set, exported as `CARGO_REGISTRY_TOKEN`.
+- `args`: extra flags forwarded to `cargo publish` via `sampo publish -- …`.
+- `base-branch`: base branch used by the release PR that `auto` prepares (defaults to the detected git branch).
+- `pr-branch`: working branch used for the release PR that `auto` prepares (defaults to `release/<current-branch>` with `/` replaced by `-`).
+- `pr-title`: title of the release PR that `auto` prepares (defaults to `Release (<current-branch>)`).
+- `stabilize-pr-branch`: working branch used for the stabilize PR that `auto` prepares (defaults to `stabilize/<current-branch>` with `/` replaced by `-`).
+- `stabilize-pr-title`: title of the stabilize PR that `auto` prepares (defaults to `Release stable (<current-branch>)`).
+- `create-github-release`: if `true`, create GitHub Releases for new tags.
+- `open-discussion`: if `true`, create a GitHub Discussion for each created release (requires GitHub Releases).
+- `discussion-category`: preferred Discussions category slug when creating releases.
+- `release-assets`: comma- or newline-separated list of paths or glob patterns for pre-built artifacts to upload when creating GitHub releases. Use `=>` to rename matches (e.g. `dist/*.zip => my-tool.zip`). Placeholders `{{tag}}`, `{{crate}}`, and `{{version}}` are available.
+- `github-token`: GitHub token to create/update PRs (defaults to `GITHUB_TOKEN` env).
+- `use-local-build`: if `true`, compile the local `sampo-github-action` binary instead of installing it with `cargo-binstall`.
 
 ## Development
 

--- a/crates/sampo-github-action/action.yml
+++ b/crates/sampo-github-action/action.yml
@@ -46,15 +46,8 @@ inputs:
   discussion-category:
     description: "Preferred Discussions category slug (default: 'announcements' if it exists)"
     required: false
-  upload-binary:
-    description: "If true, upload binary as release asset when creating GitHub releases (only for binary crates)"
-    required: false
-    default: "false"
-  binary-name:
-    description: "Binary name to upload (defaults to the main package name)"
-    required: false
-  targets:
-    description: "Space- or comma-separated Rust target triples to build and upload (must be installed). If empty, builds host only."
+  release-assets:
+    description: "Comma- or newline-separated paths/globs for pre-built release assets (optional)"
     required: false
   github-token:
     description: "GitHub token to create/update PRs (defaults to GITHUB_TOKEN env)"
@@ -92,9 +85,7 @@ runs:
         INPUT_CREATE_GITHUB_RELEASE: ${{ inputs['create-github-release'] }}
         INPUT_OPEN_DISCUSSION: ${{ inputs['open-discussion'] }}
         INPUT_DISCUSSION_CATEGORY: ${{ inputs['discussion-category'] }}
-        INPUT_UPLOAD_BINARY: ${{ inputs['upload-binary'] }}
-        INPUT_BINARY_NAME: ${{ inputs['binary-name'] }}
-        INPUT_TARGETS: ${{ inputs.targets }}
+        INPUT_RELEASE_ASSETS: ${{ inputs['release-assets'] }}
         INPUT_GITHUB_TOKEN: ${{ inputs['github-token'] }}
         INPUT_USE_LOCAL_BUILD: ${{ inputs['use-local-build'] }}
       run: |
@@ -179,11 +170,6 @@ runs:
           CREATE_GH_RELEASE_FLAG="--create-github-release"
         fi
 
-        UPLOAD_BINARY_FLAG=""
-        if [[ "${INPUT_UPLOAD_BINARY:-}" == "true" || "${INPUT_UPLOAD_BINARY:-}" == "1" ]]; then
-          UPLOAD_BINARY_FLAG="--upload-binary"
-        fi
-
         # Run sampo-github-action binary directly
         cd "${WORKDIR}"
         sampo-github-action \
@@ -195,9 +181,7 @@ runs:
           ${INPUT_BASE_BRANCH:+--base-branch "${INPUT_BASE_BRANCH}"} \
           ${INPUT_PR_BRANCH:+--pr-branch "${INPUT_PR_BRANCH}"} \
           ${INPUT_PR_TITLE:+--pr-title "${INPUT_PR_TITLE}"} \
-          ${CREATE_GH_RELEASE_FLAG} \
-          ${UPLOAD_BINARY_FLAG} \
-          ${INPUT_BINARY_NAME:+--binary-name "${INPUT_BINARY_NAME}"}
+          ${CREATE_GH_RELEASE_FLAG}
 
         # Capture outputs exposed by the binary via GITHUB_OUTPUT
         # (Already written by the binary)

--- a/crates/sampo-github-action/src/github.rs
+++ b/crates/sampo-github-action/src/github.rs
@@ -1,4 +1,5 @@
 use crate::error::{ActionError, Result};
+use reqwest::Url;
 use reqwest::blocking::Client;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
@@ -436,135 +437,56 @@ impl GitHubClient {
         }
     }
 
-    /// Upload binary as a release asset
-    pub fn upload_binary_asset(
+    /// Upload an existing file as a release asset
+    pub fn upload_release_asset(
         &self,
         upload_url: &str,
-        workspace: &Path,
-        binary_name: Option<&str>,
-        crate_name: Option<&str>,
-        target_triple: Option<&str>,
+        asset_path: &Path,
+        asset_name: &str,
     ) -> Result<()> {
-        // Determine binary name - prefer provided name, otherwise default to crate/workspace name
-        let bin_name = binary_name.unwrap_or_else(|| {
-            workspace
-                .file_name()
-                .and_then(|n| n.to_str())
-                .unwrap_or("binary")
-        });
-
-        // Build for the requested target (or host if none provided)
-        let mut cmd = std::process::Command::new("cargo");
-        cmd.arg("build").arg("--release").current_dir(workspace);
-        if let Some(triple) = target_triple {
-            cmd.arg("--target").arg(triple);
-        }
-        if let Some(pkg) = crate_name {
-            cmd.arg("-p").arg(pkg);
-        }
-        println!(
-            "Building binary{}: {}{}",
-            target_triple
-                .map(|t| format!(" for target {}", t))
-                .unwrap_or_else(|| " for host target".to_string()),
-            bin_name,
-            crate_name
-                .map(|p| format!(" (package: {})", p))
-                .unwrap_or_default(),
-        );
-
-        let output = cmd.output().map_err(ActionError::Io)?;
-        if !output.status.success() {
+        if !asset_path.is_file() {
             return Err(ActionError::SampoCommandFailed {
-                operation: "binary-build".to_string(),
+                operation: "release-asset-upload".to_string(),
                 message: format!(
-                    "Failed to build binary: {}",
-                    String::from_utf8_lossy(&output.stderr)
+                    "Release asset not found or not a file: {}",
+                    asset_path.display()
                 ),
             });
         }
 
-        // Determine target triple for naming and extension for Windows
-        let triple = target_triple
-            .map(|s| s.to_string())
-            .or_else(detect_host_triple)
-            .unwrap_or_else(|| "unknown-target".to_string());
-        let exe_suffix = if triple.contains("windows") {
-            ".exe"
-        } else {
-            ""
-        };
+        let asset_bytes = std::fs::read(asset_path).map_err(ActionError::Io)?;
 
-        // Path to the compiled binary
-        let binary_path = if let Some(triple) = target_triple {
-            workspace
-                .join("target")
-                .join(triple)
-                .join("release")
-                .join(format!("{}{}", bin_name, exe_suffix))
-        } else {
-            workspace
-                .join("target")
-                .join("release")
-                .join(format!("{}{}", bin_name, exe_suffix))
-        };
-        if !binary_path.exists() {
-            return Err(ActionError::SampoCommandFailed {
-                operation: "binary-locate".to_string(),
-                message: format!("Binary not found at {}", binary_path.display()),
-            });
-        }
-
-        // Read binary file
-        let binary_data = std::fs::read(&binary_path).map_err(ActionError::Io)?;
-
-        // Upload the binary as a release asset
-        let asset_name = format!("{}-{}{}", bin_name, triple, exe_suffix);
-        println!("Uploading binary as {}", asset_name);
+        let mut url = Url::parse(upload_url).map_err(|e| ActionError::SampoCommandFailed {
+            operation: "release-asset-upload".to_string(),
+            message: format!("Invalid upload URL '{}': {}", upload_url, e),
+        })?;
+        url.query_pairs_mut().append_pair("name", asset_name);
 
         let response = self
             .client
-            .post(format!("{}?name={}", upload_url, asset_name))
+            .post(url)
             .header("Authorization", self.auth_header())
             .header("Accept", "application/vnd.github+json")
             .header("Content-Type", "application/octet-stream")
             .header("X-GitHub-Api-Version", "2022-11-28")
-            .body(binary_data)
+            .body(asset_bytes)
             .send()
             .map_err(|e| ActionError::SampoCommandFailed {
-                operation: "binary-upload".to_string(),
+                operation: "release-asset-upload".to_string(),
                 message: format!("HTTP request failed: {}", e),
             })?;
 
         if response.status().is_success() {
-            println!("Binary uploaded successfully");
             Ok(())
         } else {
             let status = response.status();
             let error_text = response.text().unwrap_or_default();
             Err(ActionError::SampoCommandFailed {
-                operation: "binary-upload".to_string(),
-                message: format!("Failed to upload binary ({}): {}", status, error_text),
+                operation: "release-asset-upload".to_string(),
+                message: format!("Failed to upload asset ({}): {}", status, error_text),
             })
         }
     }
-}
-
-pub fn detect_host_triple() -> Option<String> {
-    let out = std::process::Command::new("rustc")
-        .arg("-vV")
-        .output()
-        .ok()?;
-    if !out.status.success() {
-        return None;
-    }
-    let s = String::from_utf8_lossy(&out.stdout);
-    for line in s.lines() {
-        if let Some(rest) = line.strip_prefix("host: ") {
-            return Some(rest.trim().to_string());
-        }
-    }
-    None
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Fix #69 . **⚠️ breaking change:** Drop the built-in binary build/upload flags in favor of a simple new `release-assets` input. Workflows should now provide pre-built artifacts (paths or glob patterns, with optional renames and templated placeholders) that the action uploads after publishing.

```diff
      - name: Install Rust targets for cross-compilation
        run: rustup target add x86_64-apple-darwin x86_64-pc-windows-msvc

+      - name: Build binaries
+        run: |
+          cargo build --release --target x86_64-unknown-linux-gnu
+          cargo build --release --target x86_64-apple-darwin
+          cargo build --release --target x86_64-pc-windows-msvc
+          mkdir -p dist
+          tar -C target/x86_64-unknown-linux-gnu/release -czf dist/my-cli-x86_64-unknown-linux-gnu.tar.gz my-cli
+          tar -C target/x86_64-apple-darwin/release -czf dist/my-cli-x86_64-apple-darwin.tar.gz my-cli
+          zip -j dist/my-cli-x86_64-pc-windows-msvc.zip target/x86_64-pc-windows-msvc/release/my-cli.exe

      - name: Run Sampo to release & publish
        uses: bruits/sampo/crates/sampo-github-action@main
        with:
          create-github-release: true
-          upload-binary: true
-          targets: x86_64-unknown-linux-gnu, x86_64-apple-darwin, x86_64-pc-windows-msvc
+          release-assets: |
+            dist/my-cli-x86_64-unknown-linux-gnu.tar.gz => my-cli-{{tag}}-x86_64-unknown-linux-gnu.tar.gz
+            dist/my-cli-x86_64-apple-darwin.tar.gz => my-cli-{{tag}}-x86_64-apple-darwin.tar.gz
+            dist/my-cli-x86_64-pc-windows-msvc.zip => my-cli-{{tag}}-x86_64-pc-windows-msvc.zip
```

## What does this change?

- `crates/sampo-github-action/src/github.rs`: replaced the previous GitHub upload helper with a simpler uploader that directly POSTs existing artifacts instead of invoking Cargo builds.
- `crates/sampo-github-action/src/main.rs`: added `release_assets` runtime input and logic to parse comma/newline-separated asset specs, resolving them via glob patterns with placeholder substitution and duplicate checks.
- Also updated `crates/sampo-github-action/action.yml` with this new behaviour.

## How is it tested?

Added unit tests for asset parsing and rendering, and updated integration tests to cover the new release asset upload behavior.

## How is it documented?

- `crates/sampo-github-action/README.md` refactored + new usage documented.