### PR TITLE
fix(github-action): use GraphQL API for GitHub Discussions

### DIFF
--- a/.sampo/changesets/forthright-shaman-kullervo.md
+++ b/.sampo/changesets/forthright-shaman-kullervo.md
@@ -1,0 +1,5 @@
+---
+sampo-github-action: patch
+---
+
+Fixed GitHub Discussions creation failing with 404 error by migrating from REST API to GraphQL API.


### PR DESCRIPTION
Fix #87 . Fixed GitHub Discussions creation failing with 404 error by migrating from REST API to GraphQL API.

## What does this change?

- `crates/sampo-github-action/src/github.rs`: migrated GitHub Discussions from non-existent REST endpoints to GraphQL API, adding `GraphQLRequest`/`GraphQLResponse` types and rewriting `get_discussion_categories()` and `create_discussion()`.

## How is it tested?

- `crates/sampo-github-action/src/github.rs`: Added `test_graphql_payload_serialization()` to verify GraphQL request structure serialization.

## How is it documented?

Expected behaviour.