### PR TITLE
refactor(core): packages support multi-ecosystem with PackageKind enum

### DIFF
--- a/crates/sampo-core/src/lib.rs
+++ b/crates/sampo-core/src/lib.rs
@@ -20,7 +20,7 @@ pub use enrichment::{
     enrich_changeset_message, get_commit_hash_for_path,
 };
 pub use errors::{Result, SampoError, WorkspaceError};
-pub use filters::{filter_members, list_visible_packages, should_ignore_crate, wildcard_match};
+pub use filters::{filter_members, list_visible_packages, should_ignore_package, wildcard_match};
 pub use git::current_branch;
 pub use manifest::{ManifestMetadata, update_manifest_versions};
 pub use markdown::format_markdown_list_item;
@@ -37,7 +37,9 @@ pub use release::{
     detect_fixed_dependency_policy_packages, format_dependency_updates_message,
     infer_bump_from_versions, run_release,
 };
-pub use types::{Bump, CrateInfo, DependencyUpdate, ReleaseOutput, ReleasedPackage, Workspace};
+pub use types::{
+    Bump, DependencyUpdate, PackageInfo, PackageKind, ReleaseOutput, ReleasedPackage, Workspace,
+};
 pub use workspace::{discover_workspace, parse_workspace_members};
 
 #[cfg(test)]

--- a/crates/sampo-core/src/prerelease.rs
+++ b/crates/sampo-core/src/prerelease.rs
@@ -2,7 +2,7 @@ use crate::discover_workspace;
 use crate::errors::{Result, SampoError};
 use crate::manifest::{ManifestMetadata, update_manifest_versions};
 use crate::release::{parse_version_string, regenerate_lockfile, restore_prerelease_changesets};
-use crate::types::{CrateInfo, Workspace};
+use crate::types::{PackageInfo, Workspace};
 use semver::{BuildMetadata, Prerelease};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
@@ -86,14 +86,14 @@ pub fn restore_preserved_changesets(root: &Path) -> Result<usize> {
 fn resolve_targets<'a>(
     workspace: &'a Workspace,
     packages: &[String],
-) -> Result<Vec<&'a CrateInfo>> {
+) -> Result<Vec<&'a PackageInfo>> {
     if packages.is_empty() {
         return Err(SampoError::Prerelease(
             "At least one package must be specified.".to_string(),
         ));
     }
 
-    let mut lookup: BTreeMap<&str, &CrateInfo> = BTreeMap::new();
+    let mut lookup: BTreeMap<&str, &PackageInfo> = BTreeMap::new();
     for info in &workspace.members {
         lookup.insert(info.name.as_str(), info);
     }
@@ -144,7 +144,7 @@ fn validate_label(label: &str) -> Result<Prerelease> {
 }
 
 fn plan_enter_updates(
-    targets: &[&CrateInfo],
+    targets: &[&PackageInfo],
     prerelease: &Prerelease,
 ) -> Result<(Vec<VersionChange>, BTreeMap<String, String>)> {
     let mut changes = Vec::new();
@@ -182,7 +182,7 @@ fn plan_enter_updates(
 }
 
 fn plan_exit_updates(
-    targets: &[&CrateInfo],
+    targets: &[&PackageInfo],
 ) -> Result<(Vec<VersionChange>, BTreeMap<String, String>)> {
     let mut changes = Vec::new();
     let mut new_versions: BTreeMap<String, String> = BTreeMap::new();

--- a/crates/sampo-core/src/publish.rs
+++ b/crates/sampo-core/src/publish.rs
@@ -1,8 +1,8 @@
-use crate::types::CrateInfo;
+use crate::types::PackageInfo;
 use crate::{
     Config, current_branch, discover_workspace,
     errors::{Result, SampoError},
-    filters::should_ignore_crate,
+    filters::should_ignore_package,
 };
 use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::fs;
@@ -45,19 +45,19 @@ pub fn run_publish(root: &std::path::Path, dry_run: bool, cargo_args: &[String])
         )));
     }
 
-    // Determine which crates are publishable to crates.io and not ignored
-    let mut name_to_crate: BTreeMap<String, &CrateInfo> = BTreeMap::new();
+    // Determine which packages are publishable to crates.io and not ignored
+    let mut name_to_package: BTreeMap<String, &PackageInfo> = BTreeMap::new();
     let mut publishable: BTreeSet<String> = BTreeSet::new();
     for c in &ws.members {
         // Skip ignored packages
-        if should_ignore_crate(&config, &ws, c)? {
+        if should_ignore_package(&config, &ws, c)? {
             continue;
         }
 
         let manifest = c.path.join("Cargo.toml");
         if is_publishable_to_crates_io(&manifest)? {
             publishable.insert(c.name.clone());
-            name_to_crate.insert(c.name.clone(), c);
+            name_to_package.insert(c.name.clone(), c);
         }
     }
 
@@ -69,7 +69,7 @@ pub fn run_publish(root: &std::path::Path, dry_run: bool, cargo_args: &[String])
     // Validate internal deps do not include non-publishable crates
     let mut errors: Vec<String> = Vec::new();
     for name in &publishable {
-        let c = name_to_crate.get(name).ok_or_else(|| {
+        let c = name_to_package.get(name).ok_or_else(|| {
             SampoError::Publish(format!(
                 "internal error: crate '{}' not found in workspace",
                 name
@@ -94,7 +94,7 @@ pub fn run_publish(root: &std::path::Path, dry_run: bool, cargo_args: &[String])
     }
 
     // Compute publish order (topological: deps first) for all publishable crates.
-    let order = topo_order(&name_to_crate, &publishable)?;
+    let order = topo_order(&name_to_package, &publishable)?;
 
     println!("Publish plan (crates.io):");
     for name in &order {
@@ -103,7 +103,7 @@ pub fn run_publish(root: &std::path::Path, dry_run: bool, cargo_args: &[String])
 
     // Execute cargo publish in order
     for name in &order {
-        let c = name_to_crate.get(name).ok_or_else(|| {
+        let c = name_to_package.get(name).ok_or_else(|| {
             SampoError::Publish(format!(
                 "internal error: crate '{}' not found in workspace",
                 name
@@ -356,26 +356,26 @@ pub fn version_exists_on_crates_io(crate_name: &str, version: &str) -> Result<bo
 /// before the crates that depend on them.
 ///
 /// # Arguments
-/// * `name_to_crate` - Map from crate names to their info
-/// * `include` - Set of crate names to include in the ordering
+/// * `name_to_package` - Map from package names to their info
+/// * `include` - Set of package names to include in the ordering
 ///
 /// # Examples
 /// ```no_run
 /// use std::collections::{BTreeMap, BTreeSet};
-/// use sampo_core::{topo_order, types::CrateInfo};
+/// use sampo_core::{topo_order, types::PackageInfo};
 /// use std::path::PathBuf;
 ///
-/// let mut crates = BTreeMap::new();
+/// let mut packages = BTreeMap::new();
 /// let mut include = BTreeSet::new();
 ///
-/// // Setup crates: foundation -> middleware -> app
-/// // ... (create CrateInfo instances) ...
+/// // Setup packages: foundation -> middleware -> app
+/// // ... (create PackageInfo instances) ...
 ///
-/// let order = topo_order(&crates, &include).unwrap();
+/// let order = topo_order(&packages, &include).unwrap();
 /// // Returns: ["foundation", "middleware", "app"]
 /// ```
 pub fn topo_order(
-    name_to_crate: &BTreeMap<String, &CrateInfo>,
+    name_to_package: &BTreeMap<String, &PackageInfo>,
     include: &BTreeSet<String>,
 ) -> Result<Vec<String>> {
     // Build graph: edge dep -> crate
@@ -388,9 +388,9 @@ pub fn topo_order(
     }
 
     for name in include {
-        let c = name_to_crate
+        let c = name_to_package
             .get(name)
-            .ok_or_else(|| SampoError::Publish(format!("missing crate info for '{}'", name)))?;
+            .ok_or_else(|| SampoError::Publish(format!("missing package info for '{}'", name)))?;
         for dep in &c.internal_deps {
             if include.contains(dep) {
                 // dep -> name
@@ -639,31 +639,35 @@ mod tests {
 
     #[test]
     fn topo_orders_deps_first() {
-        // Build a small fake graph using CrateInfo structures
-        let a = CrateInfo {
+        use crate::types::PackageKind;
+        // Build a small fake graph using PackageInfo structures
+        let a = PackageInfo {
             name: "a".into(),
             version: "0.1.0".into(),
             path: PathBuf::from("/tmp/a"),
             internal_deps: BTreeSet::new(),
+            kind: PackageKind::Cargo,
         };
         let mut deps_b = BTreeSet::new();
         deps_b.insert("a".into());
-        let b = CrateInfo {
+        let b = PackageInfo {
             name: "b".into(),
             version: "0.1.0".into(),
             path: PathBuf::from("/tmp/b"),
             internal_deps: deps_b,
+            kind: PackageKind::Cargo,
         };
         let mut deps_c = BTreeSet::new();
         deps_c.insert("b".into());
-        let c = CrateInfo {
+        let c = PackageInfo {
             name: "c".into(),
             version: "0.1.0".into(),
             path: PathBuf::from("/tmp/c"),
             internal_deps: deps_c,
+            kind: PackageKind::Cargo,
         };
 
-        let mut map: BTreeMap<String, &CrateInfo> = BTreeMap::new();
+        let mut map: BTreeMap<String, &PackageInfo> = BTreeMap::new();
         map.insert("a".into(), &a);
         map.insert("b".into(), &b);
         map.insert("c".into(), &c);
@@ -679,26 +683,29 @@ mod tests {
 
     #[test]
     fn detects_dependency_cycle() {
+        use crate::types::PackageKind;
         // Create a circular dependency: a -> b -> a
         let mut deps_a = BTreeSet::new();
         deps_a.insert("b".into());
-        let a = CrateInfo {
+        let a = PackageInfo {
             name: "a".into(),
             version: "0.1.0".into(),
             path: PathBuf::from("/tmp/a"),
             internal_deps: deps_a,
+            kind: PackageKind::Cargo,
         };
 
         let mut deps_b = BTreeSet::new();
         deps_b.insert("a".into());
-        let b = CrateInfo {
+        let b = PackageInfo {
             name: "b".into(),
             version: "0.1.0".into(),
             path: PathBuf::from("/tmp/b"),
             internal_deps: deps_b,
+            kind: PackageKind::Cargo,
         };
 
-        let mut map: BTreeMap<String, &CrateInfo> = BTreeMap::new();
+        let mut map: BTreeMap<String, &PackageInfo> = BTreeMap::new();
         map.insert("a".into(), &a);
         map.insert("b".into(), &b);
 
@@ -825,7 +832,7 @@ mod tests {
 
     #[test]
     fn skips_ignored_packages_during_publish() {
-        use crate::types::{CrateInfo, Workspace};
+        use crate::types::{PackageInfo, Workspace};
         use std::collections::BTreeSet;
 
         let temp_dir = tempfile::tempdir().unwrap();
@@ -865,20 +872,23 @@ edition = "2021"
         fs::write(examples_pkg.join("Cargo.toml"), examples_toml).unwrap();
 
         // Create a workspace with both packages
+        use crate::types::PackageKind;
         let workspace = Workspace {
             root: root.to_path_buf(),
             members: vec![
-                CrateInfo {
+                PackageInfo {
                     name: "main-package".to_string(),
                     version: "1.0.0".to_string(),
                     path: main_pkg,
                     internal_deps: BTreeSet::new(),
+                    kind: PackageKind::Cargo,
                 },
-                CrateInfo {
+                PackageInfo {
                     name: "examples-demo".to_string(),
                     version: "1.0.0".to_string(),
                     path: examples_pkg,
                     internal_deps: BTreeSet::new(),
+                    kind: PackageKind::Cargo,
                 },
             ],
         };
@@ -889,7 +899,7 @@ edition = "2021"
         let mut publishable: BTreeSet<String> = BTreeSet::new();
         for c in &workspace.members {
             // Skip ignored packages
-            if should_ignore_crate(&config, &workspace, c).unwrap() {
+            if should_ignore_package(&config, &workspace, c).unwrap() {
                 continue;
             }
 

--- a/crates/sampo-core/src/release_tests.rs
+++ b/crates/sampo-core/src/release_tests.rs
@@ -1167,23 +1167,26 @@ tempfile = "3.0"
         let ws = Workspace {
             root: PathBuf::from("/test"),
             members: vec![
-                CrateInfo {
+                PackageInfo {
                     name: "pkg-a".to_string(),
                     version: "1.0.0".to_string(),
                     path: PathBuf::from("/test/pkg-a"),
                     internal_deps: BTreeSet::from(["pkg-b".to_string()]),
+                    kind: PackageKind::Cargo,
                 },
-                CrateInfo {
+                PackageInfo {
                     name: "pkg-b".to_string(),
                     version: "1.0.0".to_string(),
                     path: PathBuf::from("/test/pkg-b"),
                     internal_deps: BTreeSet::new(),
+                    kind: PackageKind::Cargo,
                 },
-                CrateInfo {
+                PackageInfo {
                     name: "pkg-c".to_string(),
                     version: "1.0.0".to_string(),
                     path: PathBuf::from("/test/pkg-c"),
                     internal_deps: BTreeSet::new(),
+                    kind: PackageKind::Cargo,
                 },
             ],
         };
@@ -1256,11 +1259,12 @@ tempfile = "3.0"
     fn detect_all_dependency_explanations_empty_cases() {
         let ws = Workspace {
             root: PathBuf::from("/test"),
-            members: vec![CrateInfo {
+            members: vec![PackageInfo {
                 name: "pkg-a".to_string(),
                 version: "1.0.0".to_string(),
                 path: PathBuf::from("/test/pkg-a"),
                 internal_deps: BTreeSet::new(),
+                kind: PackageKind::Cargo,
             }],
         };
 

--- a/crates/sampo-core/src/types.rs
+++ b/crates/sampo-core/src/types.rs
@@ -2,6 +2,12 @@ use std::collections::BTreeSet;
 use std::path::PathBuf;
 use std::str::FromStr;
 
+/// Identifies the ecosystem a package belongs to
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PackageKind {
+    Cargo,
+}
+
 /// Information about a dependency update during release
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DependencyUpdate {
@@ -27,20 +33,21 @@ pub struct ReleaseOutput {
     pub dry_run: bool,
 }
 
-/// Information about a crate in the workspace
+/// Information about a package in the workspace
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct CrateInfo {
+pub struct PackageInfo {
     pub name: String,
     pub version: String,
     pub path: PathBuf,
     pub internal_deps: BTreeSet<String>,
+    pub kind: PackageKind,
 }
 
-/// Represents a Cargo workspace with its members
+/// Represents a workspace with its package members
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Workspace {
     pub root: PathBuf,
-    pub members: Vec<CrateInfo>,
+    pub members: Vec<PackageInfo>,
 }
 
 /// Semantic version bump types, ordered by impact

--- a/crates/sampo-core/src/workspace.rs
+++ b/crates/sampo-core/src/workspace.rs
@@ -1,5 +1,5 @@
 use crate::errors::WorkspaceError;
-use crate::types::{CrateInfo, Workspace};
+use crate::types::{PackageInfo, PackageKind, Workspace};
 use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Component, Path, PathBuf};
@@ -51,14 +51,15 @@ pub fn discover_workspace(start_dir: &Path) -> Result<Workspace> {
     }
 
     // Second pass: compute internal dependencies
-    let mut out: Vec<CrateInfo> = Vec::new();
+    let mut out: Vec<PackageInfo> = Vec::new();
     for (name, version, path, manifest) in crates {
         let internal_deps = collect_internal_deps(&path, &name_to_path, &manifest);
-        out.push(CrateInfo {
+        out.push(PackageInfo {
             name,
             version,
             path,
             internal_deps,
+            kind: PackageKind::Cargo,
         });
     }
 


### PR DESCRIPTION
Fix #95 . Replace ecosystem-specific CrateInfo with generic PackageInfo struct and add PackageKind enum to support multiple package ecosystems.

## What does this change?

- `crates/sampo-core/src/types.rs`: ...
    - ... added `PackageKind` enum designed to be extensible for future ecosystems (npm, hex, etc.) currently with only Cargo.
    - ... renamed `CrateInfo` to `PackageInfo`.
- `crates/sampo-core/src/*.rs`: changed a lot of impots/functions names/types calls based on those changes.

## How is it tested?

All existing tests still pass.

## How is it documented?

Expected behaviour.