### PR TITLE
feat(core): adopt slash-qualified canonical IDs

### DIFF
--- a/.sampo/changesets/haughty-prince-tuoni.md
+++ b/.sampo/changesets/haughty-prince-tuoni.md
@@ -1,9 +1,9 @@
 ---
-"cargo:sampo": minor
-"cargo:sampo-core": minor
-"cargo:sampo-github-action": minor
+cargo/sampo: minor
+cargo/sampo-core: minor
+cargo/sampo-github-action: minor
 ---
 
-To avoid ambiguity between packages in different ecosystems (e.g. a Rust crate and an npm package both named `example`), Sampo now assigns canonical identifiers to all packages, prefixed by their ecosystem: `cargo:example` for Rust crates, `npm:example` for npm packages, etc.
+To avoid ambiguity between packages in different ecosystems (e.g. a Rust crate and an npm package both named `example`), Sampo now assigns canonical identifiers to all packages using `<ecosystem>/<name>`, such as `cargo/example` for Rust crates or `npm/example` for JavaScript packages.
 
 Changesets, the CLI, and the GitHub Action now accept and emit ecosystem-qualified package names. Plain package names (without ecosystem prefix) are still supported when there is no ambiguity.

--- a/crates/sampo-core/src/adapters/cargo.rs
+++ b/crates/sampo-core/src/adapters/cargo.rs
@@ -518,7 +518,7 @@ mod tests {
         let packages = discover_cargo(root).unwrap();
         let pkg_a = packages.iter().find(|p| p.name == "pkg-a").unwrap();
 
-        assert_eq!(pkg_a.identifier, "cargo:pkg-a");
-        assert!(pkg_a.internal_deps.contains("cargo:pkg-b"));
+        assert_eq!(pkg_a.identifier, "cargo/pkg-a");
+        assert!(pkg_a.internal_deps.contains("cargo/pkg-b"));
     }
 }

--- a/crates/sampo-core/src/filters.rs
+++ b/crates/sampo-core/src/filters.rs
@@ -121,7 +121,7 @@ mod tests {
             members: vec![
                 PackageInfo {
                     name: "internal-tool".into(),
-                    identifier: "cargo:internal-tool".into(),
+                    identifier: "cargo/internal-tool".into(),
                     version: "0.1.0".into(),
                     path: PathBuf::from("/repo/tools/internal-tool"),
                     internal_deps: Default::default(),
@@ -129,7 +129,7 @@ mod tests {
                 },
                 PackageInfo {
                     name: "examples-lib".into(),
-                    identifier: "cargo:examples-lib".into(),
+                    identifier: "cargo/examples-lib".into(),
                     version: "0.1.0".into(),
                     path: PathBuf::from("/repo/examples/lib"),
                     internal_deps: Default::default(),
@@ -137,7 +137,7 @@ mod tests {
                 },
                 PackageInfo {
                     name: "normal".into(),
-                    identifier: "cargo:normal".into(),
+                    identifier: "cargo/normal".into(),
                     version: "0.1.0".into(),
                     path: PathBuf::from("/repo/crates/normal"),
                     internal_deps: Default::default(),
@@ -164,7 +164,7 @@ mod tests {
         };
 
         let names = list_visible_packages(&ws, &cfg).unwrap();
-        assert_eq!(names, vec!["cargo:normal".to_string()]);
+        assert_eq!(names, vec!["cargo/normal".to_string()]);
     }
 
     #[test]

--- a/crates/sampo-core/src/publish.rs
+++ b/crates/sampo-core/src/publish.rs
@@ -506,27 +506,27 @@ mod tests {
         // Build a small fake graph using PackageInfo structures
         let a = PackageInfo {
             name: "a".into(),
-            identifier: "cargo:a".into(),
+            identifier: "cargo/a".into(),
             version: "0.1.0".into(),
             path: PathBuf::from("/tmp/a"),
             internal_deps: BTreeSet::new(),
             kind: PackageKind::Cargo,
         };
         let mut deps_b = BTreeSet::new();
-        deps_b.insert("cargo:a".into());
+        deps_b.insert("cargo/a".into());
         let b = PackageInfo {
             name: "b".into(),
-            identifier: "cargo:b".into(),
+            identifier: "cargo/b".into(),
             version: "0.1.0".into(),
             path: PathBuf::from("/tmp/b"),
             internal_deps: deps_b,
             kind: PackageKind::Cargo,
         };
         let mut deps_c = BTreeSet::new();
-        deps_c.insert("cargo:b".into());
+        deps_c.insert("cargo/b".into());
         let c = PackageInfo {
             name: "c".into(),
-            identifier: "cargo:c".into(),
+            identifier: "cargo/c".into(),
             version: "0.1.0".into(),
             path: PathBuf::from("/tmp/c"),
             internal_deps: deps_c,
@@ -534,27 +534,27 @@ mod tests {
         };
 
         let mut map: BTreeMap<String, &PackageInfo> = BTreeMap::new();
-        map.insert("cargo:a".into(), &a);
-        map.insert("cargo:b".into(), &b);
-        map.insert("cargo:c".into(), &c);
+        map.insert("cargo/a".into(), &a);
+        map.insert("cargo/b".into(), &b);
+        map.insert("cargo/c".into(), &c);
 
         let mut include = BTreeSet::new();
-        include.insert("cargo:a".into());
-        include.insert("cargo:b".into());
-        include.insert("cargo:c".into());
+        include.insert("cargo/a".into());
+        include.insert("cargo/b".into());
+        include.insert("cargo/c".into());
 
         let order = topo_order(&map, &include).unwrap();
-        assert_eq!(order, vec!["cargo:a", "cargo:b", "cargo:c"]);
+        assert_eq!(order, vec!["cargo/a", "cargo/b", "cargo/c"]);
     }
 
     #[test]
     fn detects_dependency_cycle() {
         // Create a circular dependency: a -> b -> a
         let mut deps_a = BTreeSet::new();
-        deps_a.insert("cargo:b".into());
+        deps_a.insert("cargo/b".into());
         let a = PackageInfo {
             name: "a".into(),
-            identifier: "cargo:a".into(),
+            identifier: "cargo/a".into(),
             version: "0.1.0".into(),
             path: PathBuf::from("/tmp/a"),
             internal_deps: deps_a,
@@ -562,10 +562,10 @@ mod tests {
         };
 
         let mut deps_b = BTreeSet::new();
-        deps_b.insert("cargo:a".into());
+        deps_b.insert("cargo/a".into());
         let b = PackageInfo {
             name: "b".into(),
-            identifier: "cargo:b".into(),
+            identifier: "cargo/b".into(),
             version: "0.1.0".into(),
             path: PathBuf::from("/tmp/b"),
             internal_deps: deps_b,
@@ -573,12 +573,12 @@ mod tests {
         };
 
         let mut map: BTreeMap<String, &PackageInfo> = BTreeMap::new();
-        map.insert("cargo:a".into(), &a);
-        map.insert("cargo:b".into(), &b);
+        map.insert("cargo/a".into(), &a);
+        map.insert("cargo/b".into(), &b);
 
         let mut include = BTreeSet::new();
-        include.insert("cargo:a".into());
-        include.insert("cargo:b".into());
+        include.insert("cargo/a".into());
+        include.insert("cargo/b".into());
 
         let result = topo_order(&map, &include);
         assert!(result.is_err());

--- a/crates/sampo-core/src/release_tests.rs
+++ b/crates/sampo-core/src/release_tests.rs
@@ -1013,7 +1013,7 @@ tempfile = "3.0"
     #[test]
     fn formats_dependency_updates_with_canonical_identifiers() {
         let updates = vec![DependencyUpdate {
-            name: "cargo:pkg1".to_string(),
+            name: "cargo/pkg1".to_string(),
             new_version: "1.2.0".to_string(),
         }];
         let msg = format_dependency_updates_message(&updates).unwrap();
@@ -1024,18 +1024,18 @@ tempfile = "3.0"
     fn formats_dependency_updates_with_ambiguous_ecosystems() {
         let updates = vec![
             DependencyUpdate {
-                name: "cargo:shared".to_string(),
+                name: "cargo/shared".to_string(),
                 new_version: "1.1.0".to_string(),
             },
             DependencyUpdate {
-                name: "npm:shared".to_string(),
+                name: "npm/shared".to_string(),
                 new_version: "2.0.0".to_string(),
             },
         ];
         let msg = format_dependency_updates_message(&updates).unwrap();
         assert_eq!(
             msg,
-            "Updated dependencies: cargo:shared@1.1.0, npm:shared@2.0.0"
+            "Updated dependencies: cargo/shared@1.1.0, npm/shared@2.0.0"
         );
     }
 
@@ -1198,15 +1198,15 @@ tempfile = "3.0"
             members: vec![
                 PackageInfo {
                     name: "pkg-a".to_string(),
-                    identifier: "cargo:pkg-a".to_string(),
+                    identifier: "cargo/pkg-a".to_string(),
                     version: "1.0.0".to_string(),
                     path: PathBuf::from("/test/pkg-a"),
-                    internal_deps: BTreeSet::from(["cargo:pkg-b".to_string()]),
+                    internal_deps: BTreeSet::from(["cargo/pkg-b".to_string()]),
                     kind: PackageKind::Cargo,
                 },
                 PackageInfo {
                     name: "pkg-b".to_string(),
-                    identifier: "cargo:pkg-b".to_string(),
+                    identifier: "cargo/pkg-b".to_string(),
                     version: "1.0.0".to_string(),
                     path: PathBuf::from("/test/pkg-b"),
                     internal_deps: BTreeSet::new(),
@@ -1214,7 +1214,7 @@ tempfile = "3.0"
                 },
                 PackageInfo {
                     name: "pkg-c".to_string(),
-                    identifier: "cargo:pkg-c".to_string(),
+                    identifier: "cargo/pkg-c".to_string(),
                     version: "1.0.0".to_string(),
                     path: PathBuf::from("/test/pkg-c"),
                     internal_deps: BTreeSet::new(),
@@ -1253,15 +1253,15 @@ tempfile = "3.0"
         // Simulate releases: pkg-a and pkg-c get fixed bump, pkg-b gets direct bump
         let mut releases = BTreeMap::new();
         releases.insert(
-            "cargo:pkg-a".to_string(),
+            "cargo/pkg-a".to_string(),
             ("1.0.0".to_string(), "1.1.0".to_string()),
         );
         releases.insert(
-            "cargo:pkg-b".to_string(),
+            "cargo/pkg-b".to_string(),
             ("1.0.0".to_string(), "1.1.0".to_string()),
         );
         releases.insert(
-            "cargo:pkg-c".to_string(),
+            "cargo/pkg-c".to_string(),
             ("1.0.0".to_string(), "1.1.0".to_string()),
         );
 
@@ -1269,7 +1269,7 @@ tempfile = "3.0"
             detect_all_dependency_explanations(&changesets, &ws, &config, &releases).unwrap();
 
         // pkg-a should have dependency update message (depends on pkg-b)
-        let pkg_a_messages = explanations.get("cargo:pkg-a").unwrap();
+        let pkg_a_messages = explanations.get("cargo/pkg-a").unwrap();
         assert_eq!(pkg_a_messages.len(), 1);
         assert!(
             pkg_a_messages[0]
@@ -1279,7 +1279,7 @@ tempfile = "3.0"
         assert_eq!(pkg_a_messages[0].1, Bump::Patch);
 
         // pkg-c should have fixed dependency policy message (no deps but in fixed group)
-        let pkg_c_messages = explanations.get("cargo:pkg-c").unwrap();
+        let pkg_c_messages = explanations.get("cargo/pkg-c").unwrap();
         assert_eq!(pkg_c_messages.len(), 1);
         assert_eq!(
             pkg_c_messages[0].0,
@@ -1288,7 +1288,7 @@ tempfile = "3.0"
         assert_eq!(pkg_c_messages[0].1, Bump::Minor); // Inferred from version change
 
         // pkg-b should have no messages (explicit changeset)
-        assert!(!explanations.contains_key("cargo:pkg-b"));
+        assert!(!explanations.contains_key("cargo/pkg-b"));
     }
 
     #[test]
@@ -1297,7 +1297,7 @@ tempfile = "3.0"
             root: PathBuf::from("/test"),
             members: vec![PackageInfo {
                 name: "pkg-a".to_string(),
-                identifier: "cargo:pkg-a".to_string(),
+                identifier: "cargo/pkg-a".to_string(),
                 version: "1.0.0".to_string(),
                 path: PathBuf::from("/test/pkg-a"),
                 internal_deps: BTreeSet::new(),

--- a/crates/sampo-core/src/workspace.rs
+++ b/crates/sampo-core/src/workspace.rs
@@ -125,8 +125,8 @@ mod tests {
 
         let ws = discover_workspace(root).unwrap();
         let x = ws.members.iter().find(|c| c.name == "x").unwrap();
-        assert!(x.internal_deps.contains("cargo:y"));
-        assert!(x.internal_deps.contains("cargo:z"));
+        assert!(x.internal_deps.contains("cargo/y"));
+        assert!(x.internal_deps.contains("cargo/z"));
     }
 
     #[test]

--- a/crates/sampo-github-action/src/sampo.rs
+++ b/crates/sampo-github-action/src/sampo.rs
@@ -612,7 +612,7 @@ mod tests {
         let plan = capture_release_plan(root).expect("plan should succeed");
         assert!(plan.has_changes);
         assert_eq!(
-            plan.releases.get("cargo:example"),
+            plan.releases.get("cargo/example"),
             Some(&(
                 "example".to_string(),
                 "0.1.0".to_string(),

--- a/crates/sampo/README.md
+++ b/crates/sampo/README.md
@@ -45,13 +45,13 @@ A markdown file describing what changed, which packages are affected, and the ty
 
 ```
 ---
-"cargo:example": minor
+cargo/example: minor
 ---
 
 A helpful description of the change, to be read by your users.
 ```
 
-Packages are referenced by their canonical identifier (`<ecosystem>:<name>`). Pending changesets are stored in the `.sampo/changesets` directory.
+Packages are referenced by their canonical identifier (`<ecosystem>/<name>`). Pending changesets are stored in the `.sampo/changesets` directory.
 
 #### Changelog
 
@@ -126,12 +126,12 @@ show_acknowledgments = true
 [packages]
 ignore_unpublished = false
 ignore = [
-  "cargo:package-a",
+  "cargo/package-a",
   "internal-*",
   "examples/*"
 ]
-fixed = [["cargo:pkg-a", "cargo:pkg-b"], ["cargo:pkg-c", "cargo:pkg-d"]]
-linked = [["cargo:pkg-e", "cargo:pkg-f"], ["cargo:pkg-g", "cargo:pkg-h"]]
+fixed = [["cargo/pkg-a", "cargo/pkg-b"], ["cargo/pkg-c", "cargo/pkg-d"]]
+linked = [["cargo/pkg-e", "cargo/pkg-f"], ["cargo/pkg-g", "cargo/pkg-h"]]
 ```
 
 ### `[git]` section
@@ -166,18 +166,18 @@ You can ignore certain packages, so they do not appear in the CLI commands, chan
 `ignore_unpublished`: If `true` (default: `false`), ignore every package configured as not publishable. For example, `publish = false` in `Cargo.toml` for Rust packages.
 
 `ignore`: A list of glob-like patterns to ignore packages by canonical identifier, plain name, or relative path. `*` matches any sequence. Examples:
-- `cargo:internal-*`: ignores Cargo packages with names like `internal-tool`.
+- `cargo/internal-*`: ignores Cargo packages with names like `internal-tool`.
 - `examples/*`: ignores any package whose relative path starts with `examples/`.
 - `package-a`: ignores a package named exactly `package-a` (only if the name is unique across ecosystems).
 
 > [!NOTE]
-> Canonical identifiers follow the `<ecosystem>:<name>` format (e.g., `cargo:my-crate` for a Rust package). Sampo continues to accept plain names, but you'll be prompted to disambiguate if a name appears in multiple ecosystems.
+> Canonical identifiers follow the `<ecosystem>/<name>` format (e.g., `cargo/my-crate` for a Rust package). Sampo continues to accept plain names, but you'll be prompted to disambiguate if a name appears in multiple ecosystems.
 
 Sampo detects packages within the same repository that depend on each other and automatically manages their versions. By default, dependent packages are automatically patched when a workspace dependency is updated. For example: if `a@0.1.0` depends on `b@0.1.0` and `b` is updated to `0.2.0`, then `a` will be automatically bumped to `0.1.1` (patch). If `a` needs a major or minor change due to `b`'s update, it should be explicitly specified in a changeset. Some options allow customizing this behavior:
 
-`fixed`: An array of dependency groups (default: `[]`) where packages in each group are bumped together with the same version level. Each group is an array of packages. When any package in a group is updated, all other packages in the same group receive the same version bump, regardless of actual dependencies. For example: if `fixed = [["cargo:a", "cargo:b"], ["cargo:c", "cargo:d"]]` and `cargo:a` is updated to `2.0.0` (major), then `cargo:b` will also be bumped to `2.0.0`, but `cargo:c` and `cargo:d` remain unchanged.
+`fixed`: An array of dependency groups (default: `[]`) where packages in each group are bumped together with the same version level. Each group is an array of packages. When any package in a group is updated, all other packages in the same group receive the same version bump, regardless of actual dependencies. For example: if `fixed = [["cargo/a", "cargo/b"], ["cargo/c", "cargo/d"]]` and `cargo/a` is updated to `2.0.0` (major), then `cargo/b` will also be bumped to `2.0.0`, but `cargo/c` and `cargo/d` remain unchanged.
 
-`linked`: An array of dependency groups (default: `[]`) where affected packages and their dependents are bumped together using the highest bump level in the group. Each group is an array of packages. When any package in a group is updated, all packages in the same group that are affected or have workspace dependencies within the group receive the highest version bump level from the group. For example: if `linked = [["cargo:a", "cargo:b"]]` where `cargo:a` depends on `cargo:b`, when `cargo:b` is updated to `2.0.0` (major), then `cargo:a` will also be bumped to `2.0.0`. If `cargo:a` is later updated to `2.1.0` (minor), `cargo:b` remains at `2.0.0` since it's not affected. Finally, if `cargo:b` has a patch update, both `cargo:a` and `cargo:b` will be bumped with patch level since it's the highest bump in the group.
+`linked`: An array of dependency groups (default: `[]`) where affected packages and their dependents are bumped together using the highest bump level in the group. Each group is an array of packages. When any package in a group is updated, all packages in the same group that are affected or have workspace dependencies within the group receive the highest version bump level from the group. For example: if `linked = [["cargo/a", "cargo/b"]]` where `cargo/a` depends on `cargo/b`, when `cargo/b` is updated to `2.0.0` (major), then `cargo/a` will also be bumped to `2.0.0`. If `cargo/a` is later updated to `2.1.0` (minor), `cargo/b` remains at `2.0.0` since it's not affected. Finally, if `cargo/b` has a patch update, both `cargo/a` and `cargo/b` will be bumped with patch level since it's the highest bump in the group.
 
 > [!WARNING]
 > Packages cannot appear in both `fixed` and `linked` configurations.

--- a/crates/sampo/src/prerelease.rs
+++ b/crates/sampo/src/prerelease.rs
@@ -336,8 +336,7 @@ fn resolve_cli_specifiers(
 }
 
 fn canonical_from_spec(spec: &PackageSpecifier) -> Option<String> {
-    spec.kind
-        .map(|kind| format!("{}:{}", kind.as_str(), spec.name))
+    spec.kind.map(|_| spec.to_canonical_string())
 }
 
 fn display_label_from_spec(spec: &PackageSpecifier, include_kind: bool) -> String {


### PR DESCRIPTION
Fix the `Changeset error: Failed to parse changeset: invalid front matter` in release.

In my last PR, to avoid ambiguity between packages in different ecosystems (e.g. a Rust crate and an npm package both named example), Sampo now assigns colon-qualified canonical identifiers to all packages, prefixed by their ecosystem.

Sadly our changeset parser, Knope's [`changesets`](https://github.com/knope-dev/changesets) crate, splits keys using `split_once(':')` and I didn't write a proper test on my previous PRs (booooh)... So this PR adopt the `<ecosystem>/<name>` format (e.g. cargo/example).

Note: `:` is a forbiden char for package names in most registeries (Crates, npm, hex, PyPi, Maven, Gradle, etc) so it shouldn't be a problem down the road. 

## What does this change?

Well, it remplaces `:` by `/` in all canonical identifiers related logic.

## How is it tested?

In `crates/sampo-core/src/changeset.rs`, added `parse_changeset_accepts_canonical_identifiers_with_slash` and `render_changeset_markdown_with_canonical_identifier`.

## How is it documented?

The README and changeset have been updated.