### PR TITLE
feat(core/npm): lockfile regeneration

### DIFF
--- a/.sampo/changesets/haughty-witch-ilmatar.md
+++ b/.sampo/changesets/haughty-witch-ilmatar.md
@@ -5,5 +5,3 @@ cargo/sampo-github-action: minor
 ---
 
 **npm packages are now supported!** Sampo now automatically detects npm packages, and handles versioning, changelogs, and publishing—even in mixed Rust/JS workspaces.
-
-⚠️ Lockfile generation is not yet implemented.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,7 @@ Principles for how automated agents and contributors generate code and docs here
 - Self-documenting code first: expressive names and straightforward logic.
 - Comments explain why (intent, invariants, trade‑offs), not how.
 - All code, comments, documentation, commit messages, and user-facing output (CLI prompts, logs, errors) must be in English.
+- Do NOT create a documentation file to explain the implementation.
 
 ## Repository Conventions
 

--- a/crates/sampo-core/src/prerelease.rs
+++ b/crates/sampo-core/src/prerelease.rs
@@ -271,12 +271,10 @@ fn apply_version_updates(
         }
     }
 
-    if has_cargo && workspace.root.join("Cargo.lock").exists() {
-        regenerate_lockfile(&workspace.root).map_err(|err| match err {
-            SampoError::Release(msg) => SampoError::Prerelease(msg),
-            other => other,
-        })?;
-    }
+    regenerate_lockfile(workspace).map_err(|err| match err {
+        SampoError::Release(msg) => SampoError::Prerelease(msg),
+        other => other,
+    })?;
 
     Ok(())
 }

--- a/crates/sampo-core/src/types.rs
+++ b/crates/sampo-core/src/types.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 use std::str::FromStr;
 
 /// Identifies the ecosystem a package belongs to
-#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum PackageKind {
     Cargo,
     Npm,


### PR DESCRIPTION
Fix #15 . Sampo now automatically regenerates lockfiles for npm packages during releases, supporting npm, pnpm, yarn, and bun package managers.

## What does this change?

- `crates/sampo-core/src/adapters/npm.rs`: implemented `regenerate_npm_lockfile()` and `detect_workspace_package_manager()` to automatically detect and regenerate lockfiles for npm, pnpm, yarn, and bun.
- `crates/sampo-core/src/release.rs` & `crates/sampo-core/src/prerelease.rs`: call the multi-ecosystem lockfile regeneration instead of Cargo-specific logic.

## How is it tested?

Added  unit tests covering package manager detection from lockfiles, `package.json` field, precedence rules, and error cases for all supported package managers.

## How is it documented?

Expected behaviour.