### PR TITLE
fix(npm): allow private manifests without version

### DIFF
--- a/.sampo/changesets/regal-guardian-lemminkainen.md
+++ b/.sampo/changesets/regal-guardian-lemminkainen.md
@@ -1,0 +1,7 @@
+---
+cargo/sampo: patch
+cargo/sampo-core: patch
+cargo/sampo-github-action: patch
+---
+
+Npm packages marked `private: true` no longer block Sampo publish when their manifest omits `version`.


### PR DESCRIPTION
Fix #123 . Npm packages marked `private: true` no longer block Sampo publish when their manifest omits `version`.

## What does this change?

- `crates/sampo-core/src/adapters/npm.rs`: allow manifest parsing to accept missing versions when `private: true`.

## How is it tested?

- `crates/sampo-core/src/adapters/npm/npm_tests.rs`: adjusted the test suite to cover that.

## How is it documented?

Expected behaviour.