### PR TITLE
fix(cargo): add version to workspace deps with path-only

### DIFF
--- a/.sampo/changesets/venerable-witch-tuoni.md
+++ b/.sampo/changesets/venerable-witch-tuoni.md
@@ -1,0 +1,7 @@
+---
+cargo/sampo: patch
+cargo/sampo-core: patch
+cargo/sampo-github-action: patch
+---
+
+Automatically add version field to workspace dependencies with only path during release. This fixes publish failures when a workspace dependency is declared with `path = "..."` but no `version` field, which is required by cargo publish.

--- a/crates/sampo-core/src/adapters/cargo.rs
+++ b/crates/sampo-core/src/adapters/cargo.rs
@@ -511,6 +511,13 @@ fn update_workspace_dependency_item(item: &mut Item, new_version: &str) -> bool 
     match item {
         Item::Value(Value::InlineTable(table)) => {
             let current = table.get("version").and_then(Value::as_str);
+
+            // If no version exists but there's a path, add the version
+            if current.is_none() && table.contains_key("path") {
+                table.insert("version", Value::from(new_version));
+                return true;
+            }
+
             let Some(existing) = current else {
                 return false;
             };
@@ -528,6 +535,13 @@ fn update_workspace_dependency_item(item: &mut Item, new_version: &str) -> bool 
                 .get("version")
                 .and_then(Item::as_value)
                 .and_then(Value::as_str);
+
+            // If no version exists but there's a path, add the version
+            if current.is_none() && table.contains_key("path") {
+                table.insert("version", Item::Value(Value::from(new_version)));
+                return true;
+            }
+
             let Some(existing) = current else {
                 return false;
             };

--- a/crates/sampo-core/src/adapters/cargo/cargo_tests.rs
+++ b/crates/sampo-core/src/adapters/cargo/cargo_tests.rs
@@ -128,6 +128,26 @@ fn cargo_discoverer_detects_internal_deps() {
 }
 
 #[test]
+fn adds_version_to_regular_dependency_with_only_path() {
+    let input = "[package]\nname=\"demo\"\nversion=\"0.1.0\"\n\n[dependencies]\nfoo = { path = \"../foo\" }\n";
+    let mut updates = BTreeMap::new();
+    updates.insert("foo".to_string(), "0.2.0".to_string());
+
+    let (out, applied) = update_manifest_versions(
+        Path::new("/workspace/pkg/Cargo.toml"),
+        input,
+        None,
+        &updates,
+        None,
+    )
+    .unwrap();
+
+    assert!(applied.contains(&("foo".to_string(), "0.2.0".to_string())));
+    assert!(out.contains("version = \"0.2.0\""));
+    assert!(out.contains("path = \"../foo\""));
+}
+
+#[test]
 fn skips_workspace_dependencies_when_updating() {
     let input = "[package]\nname=\"demo\"\nversion=\"0.1.0\"\n\n[dependencies]\nfoo = { workspace = true, optional = true }\n";
     let mut updates = BTreeMap::new();
@@ -185,7 +205,7 @@ fn skips_workspace_dependency_with_wildcard_version() {
 }
 
 #[test]
-fn skips_workspace_dependency_without_version() {
+fn adds_version_to_workspace_dependency_with_only_path() {
     let input = "[workspace.dependencies]\nfoo = { path = \"foo\" }\n";
     let mut updates = BTreeMap::new();
     updates.insert("foo".to_string(), "0.2.0".to_string());
@@ -199,8 +219,9 @@ fn skips_workspace_dependency_without_version() {
     )
     .unwrap();
 
-    assert_eq!(out.trim_end(), input.trim_end());
-    assert!(applied.is_empty());
+    assert!(applied.contains(&("foo".to_string(), "0.2.0".to_string())));
+    assert!(out.contains("version = \"0.2.0\""));
+    assert!(out.contains("path = \"foo\""));
 }
 
 #[test]


### PR DESCRIPTION
Fix #132 . Automatically add version field to workspace dependencies with only path during release. This fixes publish failures when a workspace dependency is declared with `path = "..."` but no `version` field, which is required by cargo publish.

## What does this change?

- `crates/sampo-core/src/adapters/cargo.rs`: modified `update_workspace_dependency_item` to automatically insert version field when workspace dependency has path but no version.

## How is it tested?

- `crates/sampo-core/src/adapters/cargo/cargo_tests.rs`: renamed existing test to verify version is added to path-only workspace dependencies, and added new test for regular (non-workspace) path-only dependencies.

## How is it documented?

Expected behaviour.