### PR TITLE
fix(github-bot): single sticky approval

### DIFF
--- a/.sampo/changesets/wily-sage-otso.md
+++ b/.sampo/changesets/wily-sage-otso.md
@@ -1,0 +1,5 @@
+---
+cargo/sampo-github-bot: patch
+---
+
+Sampo GitHub Bot no longer spams change-request reviews when no changesets are found, and keeps one silent approval review in sync with the presence of changesets in the PR.

--- a/crates/sampo-github-bot/src/changeset.rs
+++ b/crates/sampo-github-bot/src/changeset.rs
@@ -1,5 +1,4 @@
 use crate::error::{BotError, Result};
-use octocrab::models::pulls::ReviewAction;
 use octocrab::models::repos::{DiffEntry, DiffEntryStatus};
 use sampo_core::changeset::{ChangesetInfo, parse_changeset};
 use sampo_core::types::{Bump, PackageSpecifier};
@@ -9,12 +8,6 @@ use std::path::Path;
 pub struct ChangesetAnalysis {
     pub has_changeset: bool,
     pub comment_markdown: String,
-    pub review: ReviewMessage,
-}
-
-pub struct ReviewMessage {
-    pub action: ReviewAction,
-    pub body: String,
 }
 
 struct ChangesetFile {
@@ -78,14 +71,9 @@ pub async fn analyze_pr_changesets(
 
     if files.is_empty() {
         let comment = build_missing_changeset_comment(&[]);
-        let review = ReviewMessage {
-            action: ReviewAction::RequestChanges,
-            body: comment.clone(),
-        };
         return Ok(ChangesetAnalysis {
             has_changeset: false,
             comment_markdown: comment,
-            review,
         });
     }
 
@@ -93,28 +81,18 @@ pub async fn analyze_pr_changesets(
 
     if parsed.valid.is_empty() {
         let comment = build_missing_changeset_comment(&parsed.issues);
-        let review = ReviewMessage {
-            action: ReviewAction::RequestChanges,
-            body: comment.clone(),
-        };
         return Ok(ChangesetAnalysis {
             has_changeset: false,
             comment_markdown: comment,
-            review,
         });
     }
 
     let packages = summarize_packages(&parsed.valid);
     let comment = build_present_changeset_comment(&packages, &parsed.issues);
-    let review = ReviewMessage {
-        action: ReviewAction::Approve,
-        body: comment.clone(),
-    };
 
     Ok(ChangesetAnalysis {
         has_changeset: true,
         comment_markdown: comment,
-        review,
     })
 }
 


### PR DESCRIPTION
Sampo GitHub Bot no longer spams change-request reviews when no changesets are found, and keeps one silent approval review in sync with the presence of changesets in the PR.

## What does this change?

- `crates/sampo-github-bot/src/main.rs`: refactored review management logic to track approval state persistently in comment metadata, submit approvals only once per PR, automatically dismiss reviews when changesets are removed, and avoid spamming change-request reviews by using sticky comments instead.
- `crates/sampo-github-bot/src/changeset.rs`: removed the `ReviewMessage` struct and `review` field from `ChangesetAnalysis`.

## How is it tested?

Added a new test `approval_state_roundtrip` that validates serialization and deserialization of approval state through comment body metadata. Can't really test much more since it rely heavily on Octocrab and Github.

## How is it documented?

N/A