### PR TITLE
feat(core/cargo): support single-package rust repo

### DIFF
--- a/.sampo/changesets/valiant-sage-aino.md
+++ b/.sampo/changesets/valiant-sage-aino.md
@@ -1,0 +1,7 @@
+---
+cargo/sampo: patch
+cargo/sampo-core: patch
+cargo/sampo-github-action: patch
+---
+
+Sampo now supports single-package Rust repositories, in addition to Cargo workspaces.

--- a/crates/sampo-core/src/adapters/cargo/cargo_tests.rs
+++ b/crates/sampo-core/src/adapters/cargo/cargo_tests.rs
@@ -93,6 +93,26 @@ fn cargo_discoverer_discovers_packages() {
 }
 
 #[test]
+fn cargo_discoverer_discovers_single_package() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+
+    fs::write(
+        root.join("Cargo.toml"),
+        "[package]\nname = \"single-crate\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+
+    let packages = discover_cargo(root).unwrap();
+    assert_eq!(packages.len(), 1);
+    assert_eq!(packages[0].name, "single-crate");
+    assert_eq!(packages[0].version, "0.1.0");
+    assert_eq!(packages[0].kind, PackageKind::Cargo);
+    assert_eq!(packages[0].path, root);
+    assert!(packages[0].internal_deps.is_empty());
+}
+
+#[test]
 fn cargo_discoverer_detects_internal_deps() {
     let temp = tempfile::tempdir().unwrap();
     let root = temp.path();

--- a/crates/sampo-core/src/workspace.rs
+++ b/crates/sampo-core/src/workspace.rs
@@ -191,6 +191,25 @@ mod tests {
     }
 
     #[test]
+    fn discover_workspace_discovers_single_cargo_package() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+
+        fs::write(
+            root.join("Cargo.toml"),
+            "[package]\nname = \"standalone-crate\"\nversion = \"1.0.0\"\n",
+        )
+        .unwrap();
+
+        let ws = discover_workspace(root).unwrap();
+        assert_eq!(ws.members.len(), 1);
+        assert_eq!(ws.members[0].name, "standalone-crate");
+        assert_eq!(ws.members[0].version, "1.0.0");
+        assert_eq!(ws.members[0].kind, PackageKind::Cargo);
+        assert_eq!(ws.members[0].path, root);
+    }
+
+    #[test]
     fn discover_workspace_discovers_npm_packages() {
         let temp = tempfile::tempdir().unwrap();
         let root = temp.path();

--- a/crates/sampo/src/ui.rs
+++ b/crates/sampo/src/ui.rs
@@ -82,7 +82,7 @@ pub fn select_packages(
 ) -> Result<Vec<String>> {
     if available.is_empty() {
         return Err(SampoError::InvalidData(
-            "No workspace packages detected. Run this command inside a Cargo workspace.".into(),
+            "No packages detected in the current directory.".into(),
         ));
     }
 
@@ -160,7 +160,7 @@ mod tests {
         let err = select_packages(&[], "prompt", "Packages").unwrap_err();
         match err {
             SampoError::InvalidData(msg) => {
-                assert!(msg.contains("No workspace packages"));
+                assert!(msg.contains("No packages detected"));
             }
             other => panic!("unexpected error: {other:?}"),
         }


### PR DESCRIPTION
Fix a stupid dead angle, found by @Princesseuh . Sampo now supports single-package Rust repositories, in addition to Cargo workspaces.

## What does this change?

- `crates/sampo-core/src/adapters/cargo.rs`: modified `discover_cargo()` to detect single-package `Cargo.toml` files (without `[workspace]` section) and treat them as standalone packages, similar to the npm adapter behavior.
- `crates/sampo/src/ui.rs`: removed two ecosystem-specific errors.

## How is it tested?

- `crates/sampo-core/src/adapters/cargo/cargo_tests.rs`: added `cargo_discoverer_discovers_single_package` unit test.
- `crates/sampo-core/src/workspace.rs`: added `discover_workspace_discovers_single_cargo_package` integration test.
- `crates/sampo/src/ui.rs`: updated existing test.

## How is it documented?

Expected behaviour.