### PR TITLE
feat(github-action): filtering open-discussion by package names

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
             dist/{{crate}}-x86_64-unknown-linux-gnu.tar.gz => {{crate}}-{{version}}-x86_64-unknown-linux-gnu.tar.gz
             dist/{{crate}}-x86_64-apple-darwin.tar.gz => {{crate}}-{{version}}-x86_64-apple-darwin.tar.gz
             dist/{{crate}}-x86_64-pc-windows-msvc.tar.gz => {{crate}}-{{version}}-x86_64-pc-windows-msvc.tar.gz
-          open-discussion: true
+          open-discussion: "sampo,sampo-github-action,sampo-github-bot"
           discussion-category: announcements
           use-local-build: true
         env:

--- a/.sampo/changesets/roguish-count-tapio.md
+++ b/.sampo/changesets/roguish-count-tapio.md
@@ -1,0 +1,5 @@
+---
+cargo/sampo-github-action: minor
+---
+
+The `open-discussion` input now accepts a comma-separated list of package names (e.g. `sampo,sampo-github-action,sampo-github-bot`) to open GitHub Discussions only for specific packages, in addition to true (all) or false (none).

--- a/crates/sampo-github-action/README.md
+++ b/crates/sampo-github-action/README.md
@@ -48,7 +48,7 @@ jobs:
 
 Set the `create-github-release` input to `true` to create a GitHub Release for each new tag created when publishing packages. The release notes are generated from the changesets included in the release.
 
-If you also set `open-discussion` to `true`, a GitHub Discussion will be created for each release, in the category specified by `discussion-category` (if provided) or the repository's default category.
+To also open a GitHub Discussion for each release, set `open-discussion` to `true` (all packages) or a comma-separated list of package names (e.g., `sampo,sampo-github-action`). Use `discussion-category` to specify the target category.
 
 ### Uploading release assets in GitHub Releases
 
@@ -111,7 +111,7 @@ The action supports the following inputs:
 - `stabilize-pr-branch`: working branch used for the stabilize PR that `auto` prepares (defaults to `stabilize/<current-branch>` with `/` replaced by `-`).
 - `stabilize-pr-title`: title of the stabilize PR that `auto` prepares (defaults to `Release stable (<current-branch>)`).
 - `create-github-release`: if `true`, create GitHub Releases for new tags.
-- `open-discussion`: if `true`, create a GitHub Discussion for each created release (requires GitHub Releases).
+- `open-discussion`: create a GitHub Discussion for released packages. Accepts `true` (all packages), `false` (none, default), or a comma-separated list of package names to filter (e.g., `sampo,sampo-github-action`). Requires `create-github-release: true`.
 - `discussion-category`: preferred Discussions category slug when creating releases.
 - `release-assets`: comma or newline separated list of paths or glob patterns for pre-built artifacts to upload when creating GitHub releases. Use `=>` to rename matches (e.g. `dist/*.zip => my-tool.zip`). Placeholders `{{tag}}`, `{{crate}}`, and `{{version}}` are available.
 - `github-token`: GitHub token to create/update PRs (defaults to `GITHUB_TOKEN` env).

--- a/crates/sampo-github-action/action.yml
+++ b/crates/sampo-github-action/action.yml
@@ -40,7 +40,7 @@ inputs:
     required: false
     default: "false"
   open-discussion:
-    description: "If true, also open a GitHub Discussion for each created release (requires GitHub releases)"
+    description: "Open GitHub Discussion for releases. Either 'true' (all packages), 'false' (none), or a comma-separated list of package names (e.g. 'sampo,sampo-github-action')"
     required: false
     default: "false"
   discussion-category:

--- a/crates/sampo-github-action/src/main.rs
+++ b/crates/sampo-github-action/src/main.rs
@@ -22,8 +22,8 @@ use std::process::ExitCode;
 struct GitHubReleaseOptions {
     /// Create GitHub releases for newly created tags during publish
     create_github_release: bool,
-    /// Also open a GitHub Discussion for each created release
-    open_discussion: bool,
+    /// Filter for which packages should have GitHub Discussions opened
+    open_discussion: DiscussionFilter,
     /// Preferred Discussions category slug (e.g., "announcements")
     discussion_category: Option<String>,
     /// Release asset patterns provided by the workflow (already-built artifacts)
@@ -34,7 +34,7 @@ impl GitHubReleaseOptions {
     fn from_config(config: &Config) -> Self {
         Self {
             create_github_release: config.create_github_release,
-            open_discussion: config.open_discussion,
+            open_discussion: config.open_discussion.clone(),
             discussion_category: config.discussion_category.clone(),
             asset_specs: parse_asset_specs(config.release_assets.as_deref()),
         }
@@ -67,6 +67,59 @@ impl Mode {
             "release" => Mode::Release,
             "publish" => Mode::Publish,
             _ => Mode::Auto,
+        }
+    }
+}
+
+/// Filter for which packages should have GitHub Discussions opened.
+///
+/// Supports:
+/// - `All`: Open discussions for all packages (when input is "true")
+/// - `None`: Never open discussions (when input is "false" or empty)
+/// - `Packages`: Only open discussions for specific packages (comma-separated list)
+#[derive(Debug, Clone)]
+enum DiscussionFilter {
+    /// Open discussions for all released packages
+    All,
+    /// Never open discussions
+    None,
+    /// Open discussions only for these specific package names
+    Packages(Vec<String>),
+}
+
+impl DiscussionFilter {
+    /// Parse the INPUT_OPEN_DISCUSSION environment variable value.
+    ///
+    /// Accepts:
+    /// - "true" -> All
+    /// - "false" or empty -> None
+    /// - "pkg1,pkg2,pkg3" -> Packages(["pkg1", "pkg2", "pkg3"])
+    fn parse(input: &str) -> Self {
+        let trimmed = input.trim();
+        if trimmed.is_empty() || trimmed.eq_ignore_ascii_case("false") {
+            DiscussionFilter::None
+        } else if trimmed.eq_ignore_ascii_case("true") {
+            DiscussionFilter::All
+        } else {
+            let packages: Vec<String> = trimmed
+                .split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect();
+            if packages.is_empty() {
+                DiscussionFilter::None
+            } else {
+                DiscussionFilter::Packages(packages)
+            }
+        }
+    }
+
+    /// Check if a discussion should be opened for a given package name.
+    fn should_open_for(&self, package_name: &str) -> bool {
+        match self {
+            DiscussionFilter::All => true,
+            DiscussionFilter::None => false,
+            DiscussionFilter::Packages(packages) => packages.iter().any(|p| p == package_name),
         }
     }
 }
@@ -111,8 +164,8 @@ struct Config {
     /// Create GitHub releases for newly created tags during publish
     create_github_release: bool,
 
-    /// Also open a GitHub Discussion for each created release
-    open_discussion: bool,
+    /// Filter for which packages should have GitHub Discussions opened
+    open_discussion: DiscussionFilter,
 
     /// Preferred Discussions category slug (e.g., "announcements")
     discussion_category: Option<String>,
@@ -170,8 +223,8 @@ impl Config {
             .unwrap_or(false);
 
         let open_discussion = std::env::var("INPUT_OPEN_DISCUSSION")
-            .map(|v| v.eq_ignore_ascii_case("true"))
-            .unwrap_or(false);
+            .map(|v| DiscussionFilter::parse(&v))
+            .unwrap_or(DiscussionFilter::None);
 
         let discussion_category = std::env::var("INPUT_DISCUSSION_CATEGORY")
             .ok()
@@ -760,8 +813,11 @@ fn create_github_release_for_tag(
         }
     }
 
-    // Optionally open a Discussion for this release
-    if github_options.open_discussion
+    // Optionally open a Discussion for this release (based on filter)
+    if let Some((package_name, _version)) = parse_tag(tag)
+        && github_options
+            .open_discussion
+            .should_open_for(&package_name)
         && let Err(e) = github_client.create_discussion(
             tag,
             &body,
@@ -1097,7 +1153,7 @@ mod tests {
             stabilize_pr_branch: None,
             stabilize_pr_title: None,
             create_github_release: false,
-            open_discussion: false,
+            open_discussion: DiscussionFilter::None,
             discussion_category: None,
             release_assets: None,
         };
@@ -1313,5 +1369,87 @@ mod tests {
         assert!(got.starts_with("- New feature"));
         assert!(!got.contains("## 2.0.0"));
         assert!(!got.contains("1.9.0"));
+    }
+
+    #[test]
+    fn test_discussion_filter_parsing() {
+        // "false" or empty -> None
+        assert!(matches!(
+            DiscussionFilter::parse("false"),
+            DiscussionFilter::None
+        ));
+        assert!(matches!(
+            DiscussionFilter::parse("FALSE"),
+            DiscussionFilter::None
+        ));
+        assert!(matches!(
+            DiscussionFilter::parse(""),
+            DiscussionFilter::None
+        ));
+        assert!(matches!(
+            DiscussionFilter::parse("  "),
+            DiscussionFilter::None
+        ));
+
+        // "true" -> All
+        assert!(matches!(
+            DiscussionFilter::parse("true"),
+            DiscussionFilter::All
+        ));
+        assert!(matches!(
+            DiscussionFilter::parse("TRUE"),
+            DiscussionFilter::All
+        ));
+        assert!(matches!(
+            DiscussionFilter::parse("True"),
+            DiscussionFilter::All
+        ));
+
+        // Package list
+        match DiscussionFilter::parse("sampo,sampo-github-action") {
+            DiscussionFilter::Packages(pkgs) => {
+                assert_eq!(pkgs, vec!["sampo", "sampo-github-action"]);
+            }
+            _ => panic!("Expected Packages variant"),
+        }
+
+        // Package list with whitespace
+        match DiscussionFilter::parse("  pkg-a , pkg-b  , pkg-c  ") {
+            DiscussionFilter::Packages(pkgs) => {
+                assert_eq!(pkgs, vec!["pkg-a", "pkg-b", "pkg-c"]);
+            }
+            _ => panic!("Expected Packages variant"),
+        }
+
+        // Single package
+        match DiscussionFilter::parse("my-crate") {
+            DiscussionFilter::Packages(pkgs) => {
+                assert_eq!(pkgs, vec!["my-crate"]);
+            }
+            _ => panic!("Expected Packages variant"),
+        }
+    }
+
+    #[test]
+    fn test_discussion_filter_should_open_for() {
+        // All opens for any package
+        let all = DiscussionFilter::All;
+        assert!(all.should_open_for("sampo"));
+        assert!(all.should_open_for("any-package"));
+
+        // None never opens
+        let none = DiscussionFilter::None;
+        assert!(!none.should_open_for("sampo"));
+        assert!(!none.should_open_for("any-package"));
+
+        // Packages only opens for listed packages
+        let packages = DiscussionFilter::Packages(vec![
+            "sampo".to_string(),
+            "sampo-github-action".to_string(),
+        ]);
+        assert!(packages.should_open_for("sampo"));
+        assert!(packages.should_open_for("sampo-github-action"));
+        assert!(!packages.should_open_for("sampo-core"));
+        assert!(!packages.should_open_for("sampo-github-bot"));
     }
 }


### PR DESCRIPTION
The `open-discussion` input now accepts a comma-separated list of package names (e.g., `sampo,sampo-github-action`) to open GitHub Discussions only for specific packages, in addition to `true` (all) or `false` (none).

## What does this change?

- `crates/sampo-github-action/src/main.rs`: Add `DiscussionFilter` enum to parse `open-discussion` as `true`, `false`, or comma-separated package list, and filter discussion creation per package.
- `.github/workflows/release.yml`: Configure `open-discussion` to not open discussion for `sampo-core`.
 
## How is it tested?

- `crates/sampo-github-action/src/main.rs`: Added `test_discussion_filter_parsing` and `test_discussion_filter_should_open_for` unit tests.

## How is it documented?

- `crates/sampo-github-action/action.yml` & `crates/sampo-github-action/README.md`: Updated `open-discussion` description to reflect new filtering capability.