### PR TITLE
feat(cli): hint users for newer version

### DIFF
--- a/.sampo/changesets/bold-stormcaller-louhi.md
+++ b/.sampo/changesets/bold-stormcaller-louhi.md
@@ -1,0 +1,5 @@
+---
+cargo/sampo: minor
+---
+
+Sampo now checks for updates once per day, and displays a hint when a newer version is available on crates.io. The check is non-blocking and fails silently if offline.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -429,6 +429,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1126,6 +1147,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
+name = "libredox"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "416f7e718bdb06000964960ffa43b4335ad4012ae8b99060261aa4a8088d5ccb"
+dependencies = [
+ "bitflags 2.10.0",
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1337,6 +1368,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
 name = "parse-zoneinfo"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1513,6 +1550,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.16",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.16",
+ "libredox",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
@@ -1766,6 +1814,7 @@ version = "0.13.0"
 dependencies = [
  "clap",
  "dialoguer",
+ "dirs",
  "rand",
  "reqwest 0.12.24",
  "rustc-hash",

--- a/crates/sampo/Cargo.toml
+++ b/crates/sampo/Cargo.toml
@@ -21,10 +21,11 @@ rustc-hash = "2.0"
 semver = "1.0.26"
 serde_json = "1.0"
 toml = "0.8"
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.12", features = ["json", "blocking"] }
 sampo-core = { version = "0.10.0", path = "../sampo-core" }
 clap = { version = "4.5", features = ["derive"] }
 dialoguer = { version = "0.11", default-features = true }
+dirs = "6.0.0"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/sampo/src/main.rs
+++ b/crates/sampo/src/main.rs
@@ -6,13 +6,17 @@ mod prerelease;
 mod publish;
 mod release;
 mod ui;
+mod version_check;
 
 use clap::Parser;
 use cli::{Cli, Commands};
 use std::process::ExitCode;
+use version_check::VersionCheckResult;
 
 fn main() -> ExitCode {
     let cli = Cli::parse();
+
+    check_and_notify_update();
 
     match cli.command {
         Commands::Init => {
@@ -69,4 +73,15 @@ fn main() -> ExitCode {
         }
     }
     ExitCode::SUCCESS
+}
+
+/// Checks for CLI updates and prints a hint if a newer version is available. Non-blocking, best-effort.
+fn check_and_notify_update() {
+    if let VersionCheckResult::UpdateAvailable { current, latest } =
+        version_check::check_for_updates()
+    {
+        ui::log_hint(&format!(
+            "A new version of Sampo is available: {current} → {latest}. Run `cargo install sampo` to update."
+        ));
+    }
 }

--- a/crates/sampo/src/ui.rs
+++ b/crates/sampo/src/ui.rs
@@ -10,7 +10,8 @@ use sampo_core::{
 use std::io;
 
 pub const SUCCESS_PREFIX: &str = "✔";
-pub const WARNING_PREFIX: &str = "⚠️";
+pub const WARNING_PREFIX: &str = "⚠";
+pub const HINT_PREFIX: &str = "💡";
 const EMPTY_SELECTION_PLACEHOLDER: &str = "(none)";
 
 pub fn log_success_value(label: &str, value: &str) {
@@ -52,6 +53,17 @@ pub fn log_warning(message: &str) {
         theme.error_prefix.clone(),
         theme.error_style.apply_to(message)
     );
+    eprintln!("{line}");
+}
+
+/// Prints a hint message to stderr with a distinct visual style.
+///
+/// Used for non-critical suggestions like update notifications.
+pub fn log_hint(message: &str) {
+    let prefix = style(HINT_PREFIX.to_string()).for_stderr().yellow();
+    let message_style = Style::new().for_stderr().yellow();
+
+    let line = format!("{} {}", prefix, message_style.apply_to(message));
     eprintln!("{line}");
 }
 

--- a/crates/sampo/src/version_check.rs
+++ b/crates/sampo/src/version_check.rs
@@ -1,0 +1,235 @@
+//! Checks whether the installed Sampo CLI is up-to-date by querying crates.io.
+//!
+//! Uses a simple file-based cache to avoid excessive network requests. The cache
+//! stores the last-known latest version and a timestamp, and is refreshed when
+//! the cache is older than a configurable TTL (default: 24 hours).
+
+use semver::Version;
+use std::fs;
+use std::io::{self, Write};
+use std::path::PathBuf;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+/// Default cache TTL: 24 hours in seconds.
+const CACHE_TTL_SECS: u64 = 24 * 60 * 60;
+
+/// Timeout for the crates.io API request.
+const REQUEST_TIMEOUT_SECS: u64 = 3;
+
+/// Current CLI version (from Cargo.toml at compile time).
+pub const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// Result of a version check operation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum VersionCheckResult {
+    /// A newer version is available on crates.io.
+    UpdateAvailable { current: String, latest: String },
+    /// The current version is up-to-date.
+    UpToDate,
+    /// The check was skipped (e.g., due to cache or network issues).
+    Skipped,
+}
+
+/// Cache entry storing the latest known version and the check timestamp.
+#[derive(Debug)]
+struct CacheEntry {
+    version: String,
+    timestamp: u64,
+}
+
+impl CacheEntry {
+    fn parse(content: &str) -> Option<Self> {
+        let mut lines = content.lines();
+        let version = lines.next()?.trim().to_string();
+        let timestamp: u64 = lines.next()?.trim().parse().ok()?;
+        if version.is_empty() {
+            return None;
+        }
+        Some(CacheEntry { version, timestamp })
+    }
+
+    fn serialize(&self) -> String {
+        format!("{}\n{}", self.version, self.timestamp)
+    }
+}
+
+/// Returns the path to the version cache file.
+///
+/// Uses the platform-appropriate cache directory:
+/// - Linux: `$XDG_CACHE_HOME/sampo` or `~/.cache/sampo`
+/// - macOS: `~/Library/Caches/sampo`
+/// - Windows: `%LOCALAPPDATA%\sampo`
+fn cache_file_path() -> Option<PathBuf> {
+    dirs::cache_dir().map(|dir| dir.join("sampo").join("version_check"))
+}
+
+/// Reads the cached version info if it exists and is still valid.
+fn read_cache(ttl_secs: u64) -> Option<String> {
+    let path = cache_file_path()?;
+    let content = fs::read_to_string(&path).ok()?;
+    let entry = CacheEntry::parse(&content)?;
+
+    let now = SystemTime::now().duration_since(UNIX_EPOCH).ok()?.as_secs();
+
+    if now.saturating_sub(entry.timestamp) < ttl_secs {
+        Some(entry.version)
+    } else {
+        None
+    }
+}
+
+/// Writes the latest version to the cache file.
+fn write_cache(version: &str) -> io::Result<()> {
+    let Some(path) = cache_file_path() else {
+        return Ok(());
+    };
+
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+
+    let entry = CacheEntry {
+        version: version.to_string(),
+        timestamp,
+    };
+
+    let mut file = fs::File::create(&path)?;
+    file.write_all(entry.serialize().as_bytes())?;
+    Ok(())
+}
+
+/// Fetches the latest version from crates.io.
+///
+/// Returns `None` on network errors, timeouts, or parse failures—these are
+/// silently ignored since version checking is best-effort.
+fn fetch_latest_version() -> Option<String> {
+    let url = "https://crates.io/api/v1/crates/sampo";
+
+    let client = reqwest::blocking::Client::builder()
+        .timeout(Duration::from_secs(REQUEST_TIMEOUT_SECS))
+        .user_agent(format!("sampo/{}", CURRENT_VERSION))
+        .build()
+        .ok()?;
+
+    let response = client.get(url).send().ok()?;
+
+    if !response.status().is_success() {
+        return None;
+    }
+
+    let json: serde_json::Value = response.json().ok()?;
+    let version = json
+        .get("crate")?
+        .get("max_stable_version")?
+        .as_str()?
+        .to_string();
+
+    Some(version)
+}
+
+/// Compares two version strings and returns true if `latest` is greater than `current`.
+fn is_newer(current: &str, latest: &str) -> bool {
+    let Ok(current_ver) = Version::parse(current) else {
+        return false;
+    };
+    let Ok(latest_ver) = Version::parse(latest) else {
+        return false;
+    };
+    latest_ver > current_ver
+}
+
+/// Performs a version check, using the cache when available.
+///
+/// This function is designed to fail silently—any network or parse errors
+/// result in `VersionCheckResult::Skipped` rather than propagating errors.
+pub fn check_for_updates() -> VersionCheckResult {
+    let current = CURRENT_VERSION;
+
+    // First, try to use cached version info
+    if let Some(cached_version) = read_cache(CACHE_TTL_SECS) {
+        if is_newer(current, &cached_version) {
+            return VersionCheckResult::UpdateAvailable {
+                current: current.to_string(),
+                latest: cached_version,
+            };
+        }
+        return VersionCheckResult::UpToDate;
+    }
+
+    // Cache is stale or missing—fetch from crates.io
+    let Some(latest) = fetch_latest_version() else {
+        return VersionCheckResult::Skipped;
+    };
+
+    // Update the cache (ignore write errors)
+    let _ = write_cache(&latest);
+
+    if is_newer(current, &latest) {
+        VersionCheckResult::UpdateAvailable {
+            current: current.to_string(),
+            latest,
+        }
+    } else {
+        VersionCheckResult::UpToDate
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cache_entry_roundtrip() {
+        let entry = CacheEntry {
+            version: "1.2.3".to_string(),
+            timestamp: 1234567890,
+        };
+        let serialized = entry.serialize();
+        let parsed = CacheEntry::parse(&serialized).expect("should parse");
+        assert_eq!(parsed.version, "1.2.3");
+        assert_eq!(parsed.timestamp, 1234567890);
+    }
+
+    #[test]
+    fn cache_entry_parse_rejects_empty() {
+        assert!(CacheEntry::parse("").is_none());
+        assert!(CacheEntry::parse("\n123").is_none());
+        assert!(CacheEntry::parse("1.0.0\n").is_none());
+        assert!(CacheEntry::parse("1.0.0\nnot_a_number").is_none());
+    }
+
+    #[test]
+    fn is_newer_compares_versions_correctly() {
+        assert!(is_newer("1.0.0", "1.0.1"));
+        assert!(is_newer("1.0.0", "1.1.0"));
+        assert!(is_newer("1.0.0", "2.0.0"));
+        assert!(is_newer("0.13.0", "0.14.0"));
+        assert!(is_newer("0.13.0", "1.0.0"));
+
+        assert!(!is_newer("1.0.0", "1.0.0"));
+        assert!(!is_newer("1.0.1", "1.0.0"));
+        assert!(!is_newer("2.0.0", "1.0.0"));
+
+        // Pre-release handling
+        assert!(is_newer("1.0.0-alpha", "1.0.0"));
+        assert!(!is_newer("1.0.0", "1.0.0-alpha"));
+    }
+
+    #[test]
+    fn is_newer_handles_invalid_versions() {
+        assert!(!is_newer("invalid", "1.0.0"));
+        assert!(!is_newer("1.0.0", "invalid"));
+        assert!(!is_newer("", "1.0.0"));
+    }
+
+    #[test]
+    fn current_version_is_valid_semver() {
+        let parsed = Version::parse(CURRENT_VERSION);
+        assert!(parsed.is_ok(), "CURRENT_VERSION should be valid semver");
+    }
+}


### PR DESCRIPTION
Sampo now checks for updates once per day, and displays a hint when a newer version is available on crates.io. The check is non-blocking and fails silently if offline.

## What does this change?

- `crates/sampo/src/version_check.rs` (new): Queries crates.io for the latest version, caches results for 24h using platform-appropriate directories via `dirs`, and compares versions using semver.

- `crates/sampo/src/ui.rs`: Adds `log_hint()` function for displaying non-critical suggestions with a 💡 prefix in yellow.

- `crates/sampo/src/main.rs`: Calls version check at startup and prints a hint if an update is available.

- `crates/sampo/Cargo.toml`: Adds `dirs` dependency for cross-platform cache directory resolution.

## How is it tested?

- `crates/sampo/src/version_check.rs`: Unit tests cover cache entry serialization/parsing, semver comparison logic, and edge cases (invalid versions, pre-releases).

## How is it documented?

N/A.