### PR TITLE
feat(core/packagist): PHP package discovery and publishing

### DIFF
--- a/.sampo/changesets/dashing-forgemaster-marjatta.md
+++ b/.sampo/changesets/dashing-forgemaster-marjatta.md
@@ -1,0 +1,5 @@
+---
+cargo/sampo-core: minor
+---
+
+Add packagist support to sampo allowing PHP libraries to be managed via sampo. It currently only support composer.toml for publishing. This is different to other supported packages because PHP doesn't work by publishing versions to a central repository but rather by tagging resources in Github.

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
   <img alt="Sampo logo" src="./.github/assets/Sampo_logo_light.svg" />
 </picture>
 
-> Steers his mighty boat in safety, Through the perils of the whirlpool, Through the watery deeps and dangers. 
+> Steers his mighty boat in safety, Through the perils of the whirlpool, Through the watery deeps and dangers.
 
-Automate changelogs, versioning, and publishing—even for monorepos across multiple package registries. Currently supported ecosystems: Rust ([Crates](https://crates.io)), JavaScript/TypeScript ([npm](https://www.npmjs.com)), Elixir ([Hex](https://hex.pm)), Python ([PyPI](https://pypi.org))... And more [coming soon](https://github.com/bruits/sampo/issues/104)!
+Automate changelogs, versioning, and publishing—even for monorepos across multiple package registries. Currently supported ecosystems: Rust ([Crates](https://crates.io)), JavaScript/TypeScript ([npm](https://www.npmjs.com)), Elixir ([Hex](https://hex.pm)), Python ([PyPI](https://pypi.org)), PHP ([Packagist](https://packagist.org))... And more [coming soon](https://github.com/bruits/sampo/issues/104)!
 
 Don't know where to start? Check out Sampo's [documentation](./crates/sampo/README.md).
 

--- a/crates/sampo-core/src/adapters.rs
+++ b/crates/sampo-core/src/adapters.rs
@@ -2,6 +2,7 @@
 pub mod cargo;
 pub mod hex;
 pub mod npm;
+pub mod packagist;
 pub mod pypi;
 
 pub use cargo::ManifestMetadata;
@@ -18,6 +19,7 @@ pub enum PackageAdapter {
     Npm,
     Hex,
     PyPI,
+    Packagist,
 }
 
 impl PackageAdapter {
@@ -29,6 +31,7 @@ impl PackageAdapter {
             PackageAdapter::Npm,
             PackageAdapter::Hex,
             PackageAdapter::PyPI,
+            PackageAdapter::Packagist,
         ]
     }
 
@@ -39,6 +42,7 @@ impl PackageAdapter {
             Self::Npm => npm::NpmAdapter.can_discover(root),
             Self::Hex => hex::HexAdapter.can_discover(root),
             Self::PyPI => pypi::PyPIAdapter.can_discover(root),
+            Self::Packagist => packagist::PackagistAdapter.can_discover(root),
         }
     }
 
@@ -49,6 +53,7 @@ impl PackageAdapter {
             Self::Npm => npm::NpmAdapter.discover(root),
             Self::Hex => hex::HexAdapter.discover(root),
             Self::PyPI => pypi::PyPIAdapter.discover(root),
+            Self::Packagist => packagist::PackagistAdapter.discover(root),
         }
     }
 
@@ -59,6 +64,7 @@ impl PackageAdapter {
             Self::Npm => npm::NpmAdapter.manifest_path(package_dir),
             Self::Hex => hex::HexAdapter.manifest_path(package_dir),
             Self::PyPI => pypi::PyPIAdapter.manifest_path(package_dir),
+            Self::Packagist => packagist::PackagistAdapter.manifest_path(package_dir),
         }
     }
 
@@ -69,6 +75,7 @@ impl PackageAdapter {
             Self::Npm => npm::NpmAdapter.is_publishable(manifest_path),
             Self::Hex => hex::HexAdapter.is_publishable(manifest_path),
             Self::PyPI => pypi::PyPIAdapter.is_publishable(manifest_path),
+            Self::Packagist => packagist::PackagistAdapter.is_publishable(manifest_path),
         }
     }
 
@@ -84,6 +91,9 @@ impl PackageAdapter {
             Self::Npm => npm::NpmAdapter.version_exists(package_name, version, manifest_path),
             Self::Hex => hex::HexAdapter.version_exists(package_name, version, manifest_path),
             Self::PyPI => pypi::PyPIAdapter.version_exists(package_name, version, manifest_path),
+            Self::Packagist => {
+                packagist::PackagistAdapter.version_exists(package_name, version, manifest_path)
+            }
         }
     }
 
@@ -99,6 +109,9 @@ impl PackageAdapter {
             Self::Npm => npm::NpmAdapter.publish(manifest_path, dry_run, extra_args),
             Self::Hex => hex::HexAdapter.publish(manifest_path, dry_run, extra_args),
             Self::PyPI => pypi::PyPIAdapter.publish(manifest_path, dry_run, extra_args),
+            Self::Packagist => {
+                packagist::PackagistAdapter.publish(manifest_path, dry_run, extra_args)
+            }
         }
     }
 
@@ -115,6 +128,7 @@ impl PackageAdapter {
             Self::Npm => npm::publish_dry_run(packages, extra_args),
             Self::Hex => hex::publish_dry_run(packages, extra_args),
             Self::PyPI => pypi::publish_dry_run(packages, extra_args),
+            Self::Packagist => packagist::publish_dry_run(packages, extra_args),
         }
     }
 
@@ -125,6 +139,7 @@ impl PackageAdapter {
             Self::Npm => npm::NpmAdapter.regenerate_lockfile(workspace_root),
             Self::Hex => hex::HexAdapter.regenerate_lockfile(workspace_root),
             Self::PyPI => pypi::PyPIAdapter.regenerate_lockfile(workspace_root),
+            Self::Packagist => packagist::PackagistAdapter.regenerate_lockfile(workspace_root),
         }
     }
 
@@ -181,6 +196,18 @@ impl PackageAdapter {
                     new_version_by_name,
                 )
             }
+            Self::Packagist => {
+                debug_assert!(
+                    metadata.is_none(),
+                    "packagist adapter does not use Cargo metadata"
+                );
+                packagist::update_manifest_versions(
+                    manifest_path,
+                    input,
+                    new_pkg_version,
+                    new_version_by_name,
+                )
+            }
         }
     }
 
@@ -191,6 +218,7 @@ impl PackageAdapter {
             PackageKind::Npm => Self::Npm,
             PackageKind::Hex => Self::Hex,
             PackageKind::PyPI => Self::PyPI,
+            PackageKind::Packagist => Self::Packagist,
         }
     }
 }

--- a/crates/sampo-core/src/adapters/packagist.rs
+++ b/crates/sampo-core/src/adapters/packagist.rs
@@ -1,0 +1,890 @@
+use crate::errors::{Result, SampoError, WorkspaceError};
+use crate::types::{PackageInfo, PackageKind};
+use reqwest::StatusCode;
+use reqwest::blocking::Client;
+use serde_json::Value as JsonValue;
+use serde_json::value::RawValue;
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::{Mutex, OnceLock};
+use std::thread;
+use std::time::{Duration, Instant};
+
+const COMPOSER_MANIFEST: &str = "composer.json";
+const PACKAGIST_API_BASE: &str = "https://packagist.org/packages";
+
+// Packagist doesn't have strict rate limits for public API, but we add a small delay for courtesy
+const PACKAGIST_RATE_LIMIT: Duration = Duration::from_millis(200);
+
+static PACKAGIST_LAST_CALL: OnceLock<Mutex<Option<Instant>>> = OnceLock::new();
+
+/// Stateless adapter for Packagist/Composer packages.
+pub(super) struct PackagistAdapter;
+
+impl PackagistAdapter {
+    pub(super) fn can_discover(&self, root: &Path) -> bool {
+        root.join(COMPOSER_MANIFEST).exists()
+    }
+
+    pub(super) fn discover(
+        &self,
+        root: &Path,
+    ) -> std::result::Result<Vec<PackageInfo>, WorkspaceError> {
+        discover_packagist(root)
+    }
+
+    pub(super) fn manifest_path(&self, package_dir: &Path) -> PathBuf {
+        package_dir.join(COMPOSER_MANIFEST)
+    }
+
+    pub(super) fn is_publishable(&self, manifest_path: &Path) -> Result<bool> {
+        let text = fs::read_to_string(manifest_path)
+            .map_err(|e| SampoError::Io(crate::errors::io_error_with_path(e, manifest_path)))?;
+        let manifest: JsonValue = serde_json::from_str(&text).map_err(|e| {
+            SampoError::Publish(format!(
+                "Invalid JSON in {}: {}",
+                manifest_path.display(),
+                e
+            ))
+        })?;
+
+        // Check for required fields
+        let name = manifest
+            .get("name")
+            .and_then(JsonValue::as_str)
+            .map(str::trim)
+            .filter(|s| !s.is_empty());
+
+        let Some(name) = name else {
+            return Err(SampoError::Publish(format!(
+                "Manifest {} is missing a 'name' field",
+                manifest_path.display()
+            )));
+        };
+
+        // Validate vendor/package format
+        if !name.contains('/') {
+            return Err(SampoError::Publish(format!(
+                "Manifest {} has invalid package name '{}': must be in 'vendor/package' format",
+                manifest_path.display(),
+                name
+            )));
+        }
+
+        // Check if package is abandoned
+        if let Some(abandoned) = manifest.get("abandoned")
+            && (abandoned.as_bool() == Some(true) || abandoned.is_string()) {
+                return Ok(false);
+            }
+
+        Ok(true)
+    }
+
+    pub(super) fn version_exists(
+        &self,
+        package_name: &str,
+        version: &str,
+        _manifest_path: Option<&Path>,
+    ) -> Result<bool> {
+        let name = package_name.trim();
+        if name.is_empty() {
+            return Err(SampoError::Publish(
+                "Package name cannot be empty when checking Packagist registry".into(),
+            ));
+        }
+
+        enforce_packagist_rate_limit();
+
+        let client = Client::builder()
+            .timeout(Duration::from_secs(10))
+            .user_agent(crate::USER_AGENT)
+            .build()
+            .map_err(|e| {
+                SampoError::Publish(format!("failed to build HTTP client for Packagist: {}", e))
+            })?;
+
+        let url = format!("{}/{}.json", PACKAGIST_API_BASE, name);
+
+        let response = client.get(&url).send().map_err(|e| {
+            SampoError::Publish(format!(
+                "failed to query Packagist registry for '{}': {}",
+                name, e
+            ))
+        })?;
+
+        let status_code = response.status();
+        match status_code {
+            StatusCode::OK => {
+                let body = response.text().map_err(|e| {
+                    SampoError::Publish(format!("failed to read Packagist response: {}", e))
+                })?;
+                let json: JsonValue = serde_json::from_str(&body).map_err(|e| {
+                    SampoError::Publish(format!("invalid JSON from Packagist: {}", e))
+                })?;
+
+                // Check if the specific version exists in package.versions
+                let versions = json
+                    .get("package")
+                    .and_then(|p| p.get("versions"))
+                    .and_then(JsonValue::as_object)
+                    .ok_or_else(|| {
+                        SampoError::Publish(format!(
+                            "Packagist response for '{}' is missing package.versions object",
+                            name
+                        ))
+                    })?;
+
+                // Packagist versions may be prefixed with 'v' (e.g., "v1.0.0" or "1.0.0")
+                let version_key = format!("v{}", version);
+                Ok(versions.contains_key(version) || versions.contains_key(&version_key))
+            }
+            StatusCode::NOT_FOUND => Ok(false),
+            StatusCode::TOO_MANY_REQUESTS => {
+                let retry_after = response
+                    .headers()
+                    .get(reqwest::header::RETRY_AFTER)
+                    .and_then(|value| value.to_str().ok())
+                    .map(|value| format!(" Retry-After: {}", value))
+                    .unwrap_or_default();
+                Err(SampoError::Publish(format!(
+                    "Packagist registry returned 429 Too Many Requests for '{}@{}'.{}",
+                    name, version, retry_after
+                )))
+            }
+            other => {
+                let body = response.text().unwrap_or_default();
+                let snippet: String = body.trim().chars().take(300).collect();
+                let snippet = snippet.split_whitespace().collect::<Vec<_>>().join(" ");
+                let body_part = if snippet.is_empty() {
+                    String::new()
+                } else {
+                    format!(" body=\"{}\"", snippet)
+                };
+                Err(SampoError::Publish(format!(
+                    "Packagist registry returned {} for '{}@{}'{}",
+                    other, name, version, body_part
+                )))
+            }
+        }
+    }
+
+    pub(super) fn publish(
+        &self,
+        manifest_path: &Path,
+        dry_run: bool,
+        extra_args: &[String],
+    ) -> Result<()> {
+        let manifest_dir = manifest_path.parent().ok_or_else(|| {
+            SampoError::Publish(format!(
+                "Manifest {} does not have a parent directory",
+                manifest_path.display()
+            ))
+        })?;
+
+        let text = fs::read_to_string(manifest_path)
+            .map_err(|e| SampoError::Io(crate::errors::io_error_with_path(e, manifest_path)))?;
+        let manifest: JsonValue = serde_json::from_str(&text).map_err(|e| {
+            SampoError::Publish(format!(
+                "Invalid JSON in {}: {}",
+                manifest_path.display(),
+                e
+            ))
+        })?;
+
+        let package = manifest
+            .get("name")
+            .and_then(JsonValue::as_str)
+            .ok_or_else(|| {
+                SampoError::Publish(format!(
+                    "Manifest {} is missing a 'name' field",
+                    manifest_path.display()
+                ))
+            })?;
+
+        // Packagist is VCS-based: it auto-updates when you push git tags.
+        // The "publish" step validates the package structure.
+        let mut cmd = Command::new("composer");
+        cmd.current_dir(manifest_dir);
+        cmd.arg("validate");
+
+        // Add --strict for more thorough validation
+        if !has_flag(extra_args, "--strict") && !has_flag(extra_args, "--no-check-all") {
+            cmd.arg("--strict");
+        }
+
+        if !extra_args.is_empty() {
+            cmd.args(extra_args);
+        }
+
+        println!("Running: {}", format_command_display(&cmd));
+
+        let status = cmd.status().map_err(|err| {
+            if err.kind() == std::io::ErrorKind::NotFound {
+                SampoError::Publish(
+                    "composer not found in PATH; install Composer to validate packages".to_string(),
+                )
+            } else {
+                SampoError::Io(err)
+            }
+        })?;
+
+        if !status.success() {
+            return Err(SampoError::Publish(format!(
+                "composer validate failed for {} (package '{}') with status {}",
+                manifest_path.display(),
+                package,
+                status
+            )));
+        }
+
+        if dry_run {
+            println!(
+                "Dry-run: package '{}' validated. Packagist will update from VCS when you push a git tag.",
+                package
+            );
+        } else {
+            println!(
+                "Package '{}' validated. Packagist will update from VCS when you push a git tag.",
+                package
+            );
+        }
+
+        Ok(())
+    }
+
+    pub(super) fn regenerate_lockfile(&self, workspace_root: &Path) -> Result<()> {
+        let manifest_path = workspace_root.join(COMPOSER_MANIFEST);
+        if !manifest_path.exists() {
+            return Err(SampoError::Release(format!(
+                "cannot regenerate lockfile; {} not found in {}",
+                COMPOSER_MANIFEST,
+                workspace_root.display()
+            )));
+        }
+
+        println!("Regenerating composer.lock…");
+
+        let mut cmd = Command::new("composer");
+        cmd.arg("update").arg("--lock").current_dir(workspace_root);
+
+        println!("Running: {}", format_command_display(&cmd));
+
+        let status = cmd.status().map_err(|err| {
+            if err.kind() == std::io::ErrorKind::NotFound {
+                SampoError::Release(
+                    "composer not found in PATH; install Composer to regenerate composer.lock"
+                        .to_string(),
+                )
+            } else {
+                SampoError::Io(err)
+            }
+        })?;
+
+        if !status.success() {
+            return Err(SampoError::Release(format!(
+                "composer update --lock failed with status {}",
+                status
+            )));
+        }
+
+        println!("composer.lock updated.");
+        Ok(())
+    }
+}
+
+pub(super) fn publish_dry_run(
+    packages: &[(&PackageInfo, &Path)],
+    extra_args: &[String],
+) -> Result<()> {
+    for (package, manifest) in packages {
+        PackagistAdapter
+            .publish(manifest, true, extra_args)
+            .map_err(|err| match err {
+                SampoError::Publish(message) => SampoError::Publish(format!(
+                    "Dry-run publish failed for {}: {}",
+                    package.display_name(true),
+                    message
+                )),
+                other => other,
+            })?;
+    }
+
+    Ok(())
+}
+
+fn enforce_packagist_rate_limit() {
+    let lock = PACKAGIST_LAST_CALL.get_or_init(|| Mutex::new(None));
+    let mut guard = match lock.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
+    let now = Instant::now();
+    if let Some(last_call) = *guard {
+        let elapsed = now.saturating_duration_since(last_call);
+        if elapsed < PACKAGIST_RATE_LIMIT {
+            thread::sleep(PACKAGIST_RATE_LIMIT - elapsed);
+        }
+    }
+    *guard = Some(now);
+}
+
+/// Update a composer.json manifest with a new package version and refreshed dependency requirements.
+pub fn update_manifest_versions(
+    manifest_path: &Path,
+    input: &str,
+    new_pkg_version: Option<&str>,
+    new_version_by_name: &BTreeMap<String, String>,
+) -> Result<(String, Vec<(String, String)>)> {
+    #[derive(serde::Deserialize)]
+    struct ComposerJsonBorrowed<'a> {
+        #[serde(borrow)]
+        version: Option<&'a RawValue>,
+        #[serde(borrow)]
+        require: Option<std::collections::HashMap<String, &'a RawValue>>,
+        #[serde(borrow, rename = "require-dev")]
+        require_dev: Option<std::collections::HashMap<String, &'a RawValue>>,
+    }
+
+    let borrowed: ComposerJsonBorrowed = serde_json::from_str(input).map_err(|err| {
+        SampoError::Release(format!(
+            "Failed to parse composer.json {}: {err}",
+            manifest_path.display()
+        ))
+    })?;
+
+    struct Replacement {
+        start: usize,
+        end: usize,
+        replacement: String,
+    }
+
+    let mut replacements: Vec<Replacement> = Vec::new();
+    let mut applied: Vec<(String, String)> = Vec::new();
+
+    // Update package version
+    if let Some(target_version) = new_pkg_version
+        && let Some(version_raw) = borrowed.version {
+            let current: String = serde_json::from_str(version_raw.get()).map_err(|err| {
+                SampoError::Release(format!(
+                    "Version field in {} is not a string: {err}",
+                    manifest_path.display()
+                ))
+            })?;
+            if current != target_version {
+                let (start, end) = raw_span(version_raw, input);
+                replacements.push(Replacement {
+                    start,
+                    end,
+                    replacement: format!("\"{target_version}\""),
+                });
+            }
+        }
+
+    // Update dependencies in require and require-dev sections
+    let sections: [(&str, Option<&std::collections::HashMap<String, &RawValue>>); 2] = [
+        ("require", borrowed.require.as_ref()),
+        ("require-dev", borrowed.require_dev.as_ref()),
+    ];
+
+    for (dep_name, new_version) in new_version_by_name {
+        let mut updated = false;
+
+        for (section_name, maybe_map) in sections {
+            let Some(map) = maybe_map else { continue };
+            let Some(raw) = map.get(dep_name.as_str()) else {
+                continue;
+            };
+            let current_spec: String = serde_json::from_str(raw.get()).map_err(|err| {
+                SampoError::Release(format!(
+                    "Dependency specifier for '{}' in {}.{} is not a string: {err}",
+                    dep_name,
+                    manifest_path.display(),
+                    section_name
+                ))
+            })?;
+
+            if let Some(new_spec) = compute_dependency_constraint(&current_spec, new_version)
+                && new_spec != current_spec
+            {
+                let (start, end) = raw_span(raw, input);
+                replacements.push(Replacement {
+                    start,
+                    end,
+                    replacement: format!("\"{new_spec}\""),
+                });
+                updated = true;
+            }
+        }
+
+        if updated {
+            applied.push((dep_name.clone(), new_version.clone()));
+        }
+    }
+
+    if replacements.is_empty() {
+        return Ok((input.to_string(), applied));
+    }
+
+    replacements.sort_by(|a, b| a.start.cmp(&b.start));
+    let mut output = input.to_string();
+    for replacement in replacements.into_iter().rev() {
+        output.replace_range(replacement.start..replacement.end, &replacement.replacement);
+    }
+
+    Ok((output, applied))
+}
+
+fn raw_span(raw: &RawValue, source: &str) -> (usize, usize) {
+    let slice = raw.get();
+    let start = unsafe { slice.as_ptr().offset_from(source.as_ptr()) };
+    assert!(
+        start >= 0,
+        "raw JSON segment is not derived from the provided source"
+    );
+    let start = start as usize;
+    assert!(
+        start + slice.len() <= source.len(),
+        "raw JSON segment exceeds source bounds"
+    );
+    let end = start + slice.len();
+    (start, end)
+}
+
+/// Compute a new Composer version constraint based on the old constraint and new version.
+fn compute_dependency_constraint(old_spec: &str, new_version: &str) -> Option<String> {
+    let trimmed = old_spec.trim();
+    if trimmed.is_empty() {
+        return Some(format!("^{}", new_version));
+    }
+
+    // Skip complex constraints with logical operators
+    if trimmed.contains("||") || trimmed.contains(" ") && !trimmed.starts_with('^') {
+        return None;
+    }
+
+    // Handle caret (^) constraints - most common in Composer
+    if let Some(rest) = trimmed.strip_prefix('^') {
+        if rest == new_version {
+            return None;
+        }
+        return Some(format!("^{}", new_version));
+    }
+
+    // Handle tilde (~) constraints
+    if let Some(rest) = trimmed.strip_prefix('~') {
+        if rest == new_version {
+            return None;
+        }
+        return Some(format!("~{}", new_version));
+    }
+
+    // Handle exact version constraints
+    if trimmed == new_version {
+        return None;
+    }
+
+    // Handle comparison operators
+    if trimmed.starts_with(">=")
+        || trimmed.starts_with("<=")
+        || trimmed.starts_with('>')
+        || trimmed.starts_with('<')
+    {
+        // Don't modify comparison constraints
+        return None;
+    }
+
+    // Wildcard constraints (e.g., "1.0.*")
+    if trimmed.contains('*') {
+        return None;
+    }
+
+    // Default: use caret constraint for new version
+    Some(format!("^{}", new_version))
+}
+
+fn discover_packagist(root: &Path) -> std::result::Result<Vec<PackageInfo>, WorkspaceError> {
+    let manifest_path = root.join(COMPOSER_MANIFEST);
+    if !manifest_path.exists() {
+        return Err(WorkspaceError::InvalidWorkspace(format!(
+            "Expected {} in {}",
+            COMPOSER_MANIFEST,
+            root.display()
+        )));
+    }
+
+    let text = fs::read_to_string(&manifest_path)
+        .map_err(|e| WorkspaceError::Io(crate::errors::io_error_with_path(e, &manifest_path)))?;
+    let manifest: JsonValue = serde_json::from_str(&text).map_err(|e| {
+        WorkspaceError::InvalidManifest(format!("{}: {}", manifest_path.display(), e))
+    })?;
+
+    let name = manifest
+        .get("name")
+        .and_then(JsonValue::as_str)
+        .ok_or_else(|| {
+            WorkspaceError::InvalidManifest(format!(
+                "missing name field in {}",
+                manifest_path.display()
+            ))
+        })?
+        .to_string();
+
+    // Validate vendor/package format
+    if !name.contains('/') {
+        return Err(WorkspaceError::InvalidManifest(format!(
+            "package name '{}' in {} must be in 'vendor/package' format",
+            name,
+            manifest_path.display()
+        )));
+    }
+
+    let version = manifest
+        .get("version")
+        .and_then(JsonValue::as_str)
+        .unwrap_or("")
+        .to_string();
+
+    let identifier = PackageInfo::dependency_identifier(PackageKind::Packagist, &name);
+
+    // Composer doesn't have native workspace support, so we only return the root package
+    let packages = vec![PackageInfo {
+        name,
+        identifier,
+        version,
+        path: root.to_path_buf(),
+        internal_deps: std::collections::BTreeSet::new(),
+        kind: PackageKind::Packagist,
+    }];
+
+    Ok(packages)
+}
+
+fn has_flag(args: &[String], flag: &str) -> bool {
+    let prefix = format!("{flag}=");
+    for arg in args {
+        if arg == flag || arg.starts_with(&prefix) {
+            return true;
+        }
+    }
+    false
+}
+
+fn format_command_display(cmd: &Command) -> String {
+    let mut text = cmd.get_program().to_string_lossy().into_owned();
+    for arg in cmd.get_args() {
+        text.push(' ');
+        text.push_str(&arg.to_string_lossy());
+    }
+    text
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::BTreeMap;
+    use std::path::Path;
+
+    #[test]
+    fn compute_dependency_constraint_caret() {
+        assert_eq!(
+            compute_dependency_constraint("^1.0.0", "2.0.0"),
+            Some("^2.0.0".to_string())
+        );
+        assert_eq!(compute_dependency_constraint("^2.0.0", "2.0.0"), None);
+    }
+
+    #[test]
+    fn compute_dependency_constraint_tilde() {
+        assert_eq!(
+            compute_dependency_constraint("~1.0.0", "2.0.0"),
+            Some("~2.0.0".to_string())
+        );
+        assert_eq!(compute_dependency_constraint("~2.0.0", "2.0.0"), None);
+    }
+
+    #[test]
+    fn compute_dependency_constraint_exact() {
+        assert_eq!(
+            compute_dependency_constraint("1.0.0", "2.0.0"),
+            Some("^2.0.0".to_string())
+        );
+        assert_eq!(compute_dependency_constraint("2.0.0", "2.0.0"), None);
+    }
+
+    #[test]
+    fn compute_dependency_constraint_skips_complex() {
+        // Complex constraints with logical operators should not be modified
+        assert_eq!(compute_dependency_constraint(">=1.0 <2.0", "2.0.0"), None);
+        assert_eq!(compute_dependency_constraint("^1.0 || ^2.0", "3.0.0"), None);
+    }
+
+    #[test]
+    fn compute_dependency_constraint_skips_comparison_operators() {
+        assert_eq!(compute_dependency_constraint(">=1.0.0", "2.0.0"), None);
+        assert_eq!(compute_dependency_constraint("<=2.0.0", "1.0.0"), None);
+        assert_eq!(compute_dependency_constraint(">1.0.0", "2.0.0"), None);
+        assert_eq!(compute_dependency_constraint("<2.0.0", "1.0.0"), None);
+    }
+
+    #[test]
+    fn compute_dependency_constraint_skips_wildcard() {
+        assert_eq!(compute_dependency_constraint("1.0.*", "1.1.0"), None);
+        assert_eq!(compute_dependency_constraint("2.*", "2.1.0"), None);
+    }
+
+    #[test]
+    fn compute_dependency_constraint_empty_uses_caret() {
+        assert_eq!(
+            compute_dependency_constraint("", "1.0.0"),
+            Some("^1.0.0".to_string())
+        );
+    }
+
+    #[test]
+    fn update_manifest_versions_updates_version() {
+        let input = r#"{
+    "name": "vendor/package",
+    "version": "1.0.0",
+    "require": {}
+}"#;
+
+        let new_version_by_name = BTreeMap::new();
+        let (output, applied) = update_manifest_versions(
+            Path::new("composer.json"),
+            input,
+            Some("2.0.0"),
+            &new_version_by_name,
+        )
+        .unwrap();
+
+        assert!(output.contains(r#""version": "2.0.0""#));
+        assert!(applied.is_empty());
+    }
+
+    #[test]
+    fn update_manifest_versions_updates_dependencies() {
+        let input = r#"{
+    "name": "vendor/package",
+    "version": "1.0.0",
+    "require": {
+        "other/dep": "^1.0.0"
+    }
+}"#;
+
+        let mut new_version_by_name = BTreeMap::new();
+        new_version_by_name.insert("other/dep".to_string(), "2.0.0".to_string());
+
+        let (output, applied) = update_manifest_versions(
+            Path::new("composer.json"),
+            input,
+            None,
+            &new_version_by_name,
+        )
+        .unwrap();
+
+        assert!(output.contains(r#""other/dep": "^2.0.0""#));
+        assert_eq!(applied.len(), 1);
+        assert_eq!(applied[0].0, "other/dep");
+        assert_eq!(applied[0].1, "2.0.0");
+    }
+
+    #[test]
+    fn update_manifest_versions_updates_dev_dependencies() {
+        let input = r#"{
+    "name": "vendor/package",
+    "version": "1.0.0",
+    "require-dev": {
+        "dev/package": "^1.0.0"
+    }
+}"#;
+
+        let mut new_version_by_name = BTreeMap::new();
+        new_version_by_name.insert("dev/package".to_string(), "3.0.0".to_string());
+
+        let (output, applied) = update_manifest_versions(
+            Path::new("composer.json"),
+            input,
+            None,
+            &new_version_by_name,
+        )
+        .unwrap();
+
+        assert!(output.contains(r#""dev/package": "^3.0.0""#));
+        assert_eq!(applied.len(), 1);
+    }
+
+    #[test]
+    fn update_manifest_versions_preserves_tilde_constraint() {
+        let input = r#"{
+    "name": "vendor/package",
+    "version": "1.0.0",
+    "require": {
+        "other/dep": "~1.0.0"
+    }
+}"#;
+
+        let mut new_version_by_name = BTreeMap::new();
+        new_version_by_name.insert("other/dep".to_string(), "2.0.0".to_string());
+
+        let (output, _) = update_manifest_versions(
+            Path::new("composer.json"),
+            input,
+            None,
+            &new_version_by_name,
+        )
+        .unwrap();
+
+        assert!(output.contains(r#""other/dep": "~2.0.0""#));
+    }
+
+    #[test]
+    fn update_manifest_versions_no_changes_when_same_version() {
+        let input = r#"{
+    "name": "vendor/package",
+    "version": "1.0.0",
+    "require": {
+        "other/dep": "^1.0.0"
+    }
+}"#;
+
+        let mut new_version_by_name = BTreeMap::new();
+        new_version_by_name.insert("other/dep".to_string(), "1.0.0".to_string());
+
+        let (output, applied) = update_manifest_versions(
+            Path::new("composer.json"),
+            input,
+            Some("1.0.0"),
+            &new_version_by_name,
+        )
+        .unwrap();
+
+        // No changes when versions are the same
+        assert_eq!(output, input);
+        assert!(applied.is_empty());
+    }
+
+    #[test]
+    fn discover_packagist_valid_package() {
+        let temp = tempfile::tempdir().unwrap();
+        let manifest = r#"{
+    "name": "vendor/my-package",
+    "version": "1.2.3",
+    "require": {}
+}"#;
+        std::fs::write(temp.path().join("composer.json"), manifest).unwrap();
+
+        let packages = discover_packagist(temp.path()).unwrap();
+        assert_eq!(packages.len(), 1);
+
+        let pkg = &packages[0];
+        assert_eq!(pkg.name, "vendor/my-package");
+        assert_eq!(pkg.version, "1.2.3");
+        assert_eq!(pkg.kind, PackageKind::Packagist);
+        assert_eq!(pkg.identifier, "packagist/vendor/my-package");
+    }
+
+    #[test]
+    fn discover_packagist_requires_vendor_format() {
+        let temp = tempfile::tempdir().unwrap();
+        let manifest = r#"{
+    "name": "my-package",
+    "version": "1.0.0"
+}"#;
+        std::fs::write(temp.path().join("composer.json"), manifest).unwrap();
+
+        let result = discover_packagist(temp.path());
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("vendor/package"));
+    }
+
+    #[test]
+    fn discover_packagist_missing_name() {
+        let temp = tempfile::tempdir().unwrap();
+        let manifest = r#"{
+    "version": "1.0.0"
+}"#;
+        std::fs::write(temp.path().join("composer.json"), manifest).unwrap();
+
+        let result = discover_packagist(temp.path());
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("missing name"));
+    }
+
+    #[test]
+    fn is_publishable_valid_package() {
+        let temp = tempfile::tempdir().unwrap();
+        let manifest = r#"{
+    "name": "vendor/package",
+    "version": "1.0.0"
+}"#;
+        let path = temp.path().join("composer.json");
+        std::fs::write(&path, manifest).unwrap();
+
+        let result = PackagistAdapter.is_publishable(&path).unwrap();
+        assert!(result);
+    }
+
+    #[test]
+    fn is_publishable_abandoned_package() {
+        let temp = tempfile::tempdir().unwrap();
+        let manifest = r#"{
+    "name": "vendor/package",
+    "version": "1.0.0",
+    "abandoned": true
+}"#;
+        let path = temp.path().join("composer.json");
+        std::fs::write(&path, manifest).unwrap();
+
+        let result = PackagistAdapter.is_publishable(&path).unwrap();
+        assert!(!result);
+    }
+
+    #[test]
+    fn is_publishable_abandoned_with_replacement() {
+        let temp = tempfile::tempdir().unwrap();
+        let manifest = r#"{
+    "name": "vendor/package",
+    "version": "1.0.0",
+    "abandoned": "vendor/new-package"
+}"#;
+        let path = temp.path().join("composer.json");
+        std::fs::write(&path, manifest).unwrap();
+
+        let result = PackagistAdapter.is_publishable(&path).unwrap();
+        assert!(!result);
+    }
+
+    #[test]
+    fn is_publishable_missing_vendor_prefix() {
+        let temp = tempfile::tempdir().unwrap();
+        let manifest = r#"{
+    "name": "package-without-vendor",
+    "version": "1.0.0"
+}"#;
+        let path = temp.path().join("composer.json");
+        std::fs::write(&path, manifest).unwrap();
+
+        let result = PackagistAdapter.is_publishable(&path);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("vendor/package"));
+    }
+
+    #[test]
+    fn has_flag_detects_simple_flag() {
+        let args = vec!["--strict".to_string(), "--verbose".to_string()];
+        assert!(has_flag(&args, "--strict"));
+        assert!(has_flag(&args, "--verbose"));
+        assert!(!has_flag(&args, "--quiet"));
+    }
+
+    #[test]
+    fn has_flag_detects_value_flag() {
+        let args = vec!["--format=json".to_string()];
+        assert!(has_flag(&args, "--format"));
+        assert!(!has_flag(&args, "--output"));
+    }
+}

--- a/crates/sampo-core/src/filters.rs
+++ b/crates/sampo-core/src/filters.rs
@@ -19,6 +19,7 @@ pub fn should_ignore_package(cfg: &Config, ws: &Workspace, info: &PackageInfo) -
             crate::types::PackageKind::Npm => PackageAdapter::Npm,
             crate::types::PackageKind::Hex => PackageAdapter::Hex,
             crate::types::PackageKind::PyPI => PackageAdapter::PyPI,
+            crate::types::PackageKind::Packagist => PackageAdapter::Packagist,
         };
         let manifest = adapter.manifest_path(&info.path);
         if !adapter.is_publishable(&manifest)? {

--- a/crates/sampo-core/src/prerelease.rs
+++ b/crates/sampo-core/src/prerelease.rs
@@ -252,13 +252,15 @@ fn apply_version_updates(
             PackageKind::Npm => PackageAdapter::Npm,
             PackageKind::Hex => PackageAdapter::Hex,
             PackageKind::PyPI => PackageAdapter::PyPI,
+            PackageKind::Packagist => PackageAdapter::Packagist,
         };
         let manifest_path = adapter.manifest_path(&info.path);
         let original = fs::read_to_string(&manifest_path)?;
         let new_pkg_version = new_versions.get(&info.name).map(|s| s.as_str());
-        let metadata_ref = match info.kind {
-            PackageKind::Cargo => manifest_metadata.as_ref(),
-            PackageKind::Npm | PackageKind::Hex | PackageKind::PyPI => None,
+        let metadata_ref = if info.kind == PackageKind::Cargo {
+            manifest_metadata.as_ref()
+        } else {
+            None
         };
         let (updated, _deps) = adapter.update_manifest_versions(
             &manifest_path,

--- a/crates/sampo-core/src/publish.rs
+++ b/crates/sampo-core/src/publish.rs
@@ -74,6 +74,7 @@ pub fn run_publish(
             crate::types::PackageKind::Npm => PackageAdapter::Npm,
             crate::types::PackageKind::Hex => PackageAdapter::Hex,
             crate::types::PackageKind::PyPI => PackageAdapter::PyPI,
+            crate::types::PackageKind::Packagist => PackageAdapter::Packagist,
         };
 
         let manifest = adapter.manifest_path(&c.path);

--- a/crates/sampo-core/src/release.rs
+++ b/crates/sampo-core/src/release.rs
@@ -816,6 +816,7 @@ pub(crate) fn regenerate_lockfile(workspace: &Workspace) -> Result<()> {
             PackageKind::Npm => PackageAdapter::Npm,
             PackageKind::Hex => PackageAdapter::Hex,
             PackageKind::PyPI => PackageAdapter::PyPI,
+            PackageKind::Packagist => PackageAdapter::Packagist,
         };
 
         let lockfile_exists = match kind {
@@ -829,6 +830,7 @@ pub(crate) fn regenerate_lockfile(workspace: &Workspace) -> Result<()> {
             }
             PackageKind::Hex => workspace.root.join("mix.lock").exists(),
             PackageKind::PyPI => workspace.root.join("uv.lock").exists(),
+            PackageKind::Packagist => workspace.root.join("composer.lock").exists(),
         };
 
         if lockfile_exists && let Err(e) = adapter.regenerate_lockfile(&workspace.root) {
@@ -1337,6 +1339,7 @@ fn apply_releases(
             PackageKind::Npm => crate::adapters::PackageAdapter::Npm,
             PackageKind::Hex => crate::adapters::PackageAdapter::Hex,
             PackageKind::PyPI => crate::adapters::PackageAdapter::PyPI,
+            PackageKind::Packagist => crate::adapters::PackageAdapter::Packagist,
         };
         let manifest_path = adapter.manifest_path(&info.path);
         let text = fs::read_to_string(&manifest_path)?;
@@ -1344,7 +1347,10 @@ fn apply_releases(
         // Update manifest versions
         let cargo_metadata = match adapter {
             PackageAdapter::Cargo => manifest_metadata.as_ref(),
-            PackageAdapter::Npm | PackageAdapter::Hex | PackageAdapter::PyPI => None,
+            PackageAdapter::Npm
+            | PackageAdapter::Hex
+            | PackageAdapter::PyPI
+            | PackageAdapter::Packagist => None,
         };
         let (updated, _dep_updates) = adapter.update_manifest_versions(
             &manifest_path,

--- a/crates/sampo-core/src/types.rs
+++ b/crates/sampo-core/src/types.rs
@@ -9,6 +9,7 @@ pub enum PackageKind {
     Npm,
     Hex,
     PyPI,
+    Packagist,
 }
 
 impl PackageKind {
@@ -19,6 +20,7 @@ impl PackageKind {
             Self::Npm => "npm",
             Self::Hex => "hex",
             Self::PyPI => "pypi",
+            Self::Packagist => "packagist",
         }
     }
 
@@ -29,6 +31,7 @@ impl PackageKind {
             Self::Npm => "npm",
             Self::Hex => "Hex",
             Self::PyPI => "PyPI",
+            Self::Packagist => "Packagist",
         }
     }
 
@@ -48,6 +51,7 @@ impl PackageKind {
             "npm" => Some(Self::Npm),
             "hex" => Some(Self::Hex),
             "pypi" => Some(Self::PyPI),
+            "packagist" => Some(Self::Packagist),
             _ => None,
         }
     }

--- a/crates/sampo/README.md
+++ b/crates/sampo/README.md
@@ -1,6 +1,6 @@
 # Sampo
 
-Automate changelogs, versioning, and publishing—even for monorepos across multiple package registries. Currently supported ecosystems: Rust ([Crates](https://crates.io)), JavaScript/TypeScript ([npm](https://www.npmjs.com)), Elixir ([Hex](https://hex.pm)), Python ([PyPI](https://pypi.org))... And more [coming soon](https://github.com/bruits/sampo/issues/104)!
+Automate changelogs, versioning, and publishing—even for monorepos across multiple package registries. Currently supported ecosystems: Rust ([Crates](https://crates.io)), JavaScript/TypeScript ([npm](https://www.npmjs.com)), Elixir ([Hex](https://hex.pm)), Python ([PyPI](https://pypi.org)), PHP ([Packagist](https://packagist.org))... And more [coming soon](https://github.com/bruits/sampo/issues/104)!
 
 **In a nutshell,** Sampo is a CLI, a GitHub App, and a GitHub Action, that automatically detects packages in your repository, and uses changesets (markdown files describing changes explicitly) to bump versions (in SemVer format), generate changelogs (human-readable files listing changes), and publish packages (to their respective registries). It's designed to be easy to opt-in and opt-out, with minimal configuration required, sensible defaults, and no assumptions/constraints on your workflow (except using SemVer).
 
@@ -35,6 +35,7 @@ This command creates a `.sampo` directory at your repository root:
 #### Versioning
 
 Sampo enforces [Semantic Versioning](https://semver.org/) (SemVer) to indicate the nature of changes in each release. Versions follow the `MAJOR.MINOR.PATCH` format with three bump levels:
+
 - **patch**: Bug fixes and backwards-compatible changes
 - **minor**: New features that are backwards-compatible
 - **major**: Breaking changes that are not backwards-compatible
@@ -104,7 +105,7 @@ Finally, run `sampo publish` to publish updated packages to their respective reg
 > Always run `sampo release` before `sampo publish` to ensure versions are properly updated.
 
 > [!WARNING]
-> Publishing adapters call the native tooling (`cargo`, `npm`, `mix`, …) directly. In local or CI environments, make sure those tools are installed and accessible via your `PATH`.
+> Publishing adapters call the native tooling (`cargo`, `npm`, `mix`, `pip`/`twine`, `composer`, …) directly. In local or CI environments, make sure those tools are installed and accessible via your `PATH`.
 
 #### Pre-release versions
 
@@ -115,7 +116,7 @@ While in pre-release mode, you can continue to add changesets and run `sampo rel
 ## Configuration
 
 > [!NOTE]
-> Since Sampo automatically detects packages in your workspace (based on ecosystem conventions) and infers sensible defaults for most settings, you can often skip this section and use Sampo out-of-the-box. 
+> Since Sampo automatically detects packages in your workspace (based on ecosystem conventions) and infers sensible defaults for most settings, you can often skip this section and use Sampo out-of-the-box.
 
 The `.sampo/config.toml` file allows you to customize Sampo's behavior. Example configuration:
 
@@ -184,13 +185,14 @@ You can ignore certain packages, so they do not appear in the CLI commands, chan
 `ignore_unpublished`: If `true` (default: `false`), ignore every package configured as not publishable. For example, `publish = false` in `Cargo.toml` for Rust crates or `"private": true` in a workspace `package.json` for npm packages. By default, Sampo still tracks versioning and changelogs for those packages, but will not attempt to publish them to their registries.
 
 `ignore`: A list of glob-like patterns to ignore packages by canonical identifier, plain name, or relative path. `*` matches any sequence. Examples:
+
 - `cargo/internal-*`: ignores Cargo packages with names like `internal-tool`.
 - `npm/web-*`: ignores npm packages whose names start with `web-`.
 - `examples/*`: ignores any package whose relative path starts with `examples/`.
 - `package-a`: ignores a package named exactly `package-a` (only if the name is unique across ecosystems).
 
 > [!NOTE]
-> Canonical identifiers follow the `<ecosystem>/<name>` format (e.g., `cargo/my-crate` for a Rust package, `npm/web-app` for a JavaScript package). Sampo continues to accept plain names, but you'll be prompted to disambiguate if a name appears in multiple ecosystems.
+> Canonical identifiers follow the `<ecosystem>/<name>` format (e.g., `cargo/my-crate` for a Rust package, `npm/web-app` for a JavaScript package, `packagist/vendor/package` for a PHP package). Sampo continues to accept plain names, but you'll be prompted to disambiguate if a name appears in multiple ecosystems.
 
 Sampo detects packages within the same repository that depend on each other and automatically manages their versions. By default, dependent packages are automatically patched when a workspace dependency is updated. For example: if `a@0.1.0` depends on `b@0.1.0` and `b` is updated to `0.2.0`, then `a` will be automatically bumped to `0.1.1` (patch). If `a` needs a major or minor change due to `b`'s update, it should be explicitly specified in a changeset. Some options allow customizing this behavior:
 


### PR DESCRIPTION
## What has changed?

This adds support for PHP to sampo! It's only for those using `composer.toml` at the moment but I thought this was a good start - and what we need over at posthog/posthog-php.

PHP is slightly different than other libraries because there's no such thing as publishing, we simply need to push a new tag to Git. I've tried this locally and it seems to be working well, would be good to see it land here!

## How is it tested?

Locally using the posthog/posthog-php repository

## How is it documented?

Reasonable docs were added to showcase this is now available, also added a changeset
