### PR TITLE
fix(core/enrichment): credit changeset original creator

### DIFF
--- a/.sampo/changesets/dashing-baron-marjatta.md
+++ b/.sampo/changesets/dashing-baron-marjatta.md
@@ -1,0 +1,7 @@
+---
+cargo/sampo: patch
+cargo/sampo-core: patch
+cargo/sampo-github-action: patch
+---
+
+Changelog entries now correctly credit the original changeset author, even if the file was later edited by someone else.

--- a/crates/sampo-core/src/adapters/hex.rs
+++ b/crates/sampo-core/src/adapters/hex.rs
@@ -1,7 +1,7 @@
 use crate::errors::{Result, SampoError, WorkspaceError};
 use crate::types::PackageInfo;
-use reqwest::blocking::Client;
 use reqwest::StatusCode;
+use reqwest::blocking::Client;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 use std::sync::{Mutex, OnceLock};

--- a/crates/sampo-core/src/adapters/npm.rs
+++ b/crates/sampo-core/src/adapters/npm.rs
@@ -2,8 +2,8 @@ use crate::errors::{Result, SampoError, WorkspaceError};
 use crate::types::{PackageInfo, PackageKind};
 use reqwest::StatusCode;
 use serde::Deserialize;
-use serde_json::value::RawValue;
 use serde_json::Value as JsonValue;
+use serde_json::value::RawValue;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fs;
 use std::path::{Component, Path, PathBuf};
@@ -63,11 +63,7 @@ impl NpmAdapter {
     pub(super) fn is_publishable(&self, manifest_path: &Path) -> Result<bool> {
         let manifest = load_package_json(manifest_path)?;
         let info = parse_manifest_info(manifest_path, &manifest)?;
-        if info.private {
-            Ok(false)
-        } else {
-            Ok(true)
-        }
+        if info.private { Ok(false) } else { Ok(true) }
     }
 
     pub(super) fn version_exists(

--- a/crates/sampo-core/src/adapters/pypi.rs
+++ b/crates/sampo-core/src/adapters/pypi.rs
@@ -1,7 +1,7 @@
 use crate::errors::{Result, SampoError, WorkspaceError};
 use crate::types::PackageInfo;
-use reqwest::blocking::Client;
 use reqwest::StatusCode;
+use reqwest::blocking::Client;
 use serde_json::Value as JsonValue;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};

--- a/crates/sampo-core/src/adapters/pypi/pip/pip_tests.rs
+++ b/crates/sampo-core/src/adapters/pypi/pip/pip_tests.rs
@@ -76,7 +76,10 @@ dependencies = []
     let packages = discover(root).unwrap();
     assert_eq!(packages.len(), 3);
 
-    let root_pkg = packages.iter().find(|p| p.name == "workspace-root").unwrap();
+    let root_pkg = packages
+        .iter()
+        .find(|p| p.name == "workspace-root")
+        .unwrap();
     assert!(root_pkg.internal_deps.contains("pypi/pkg-a"));
 
     let pkg_a = packages.iter().find(|p| p.name == "pkg-a").unwrap();

--- a/crates/sampo-core/src/lib.rs
+++ b/crates/sampo-core/src/lib.rs
@@ -18,20 +18,20 @@ pub const USER_AGENT: &str = concat!("sampo-core/", env!("CARGO_PKG_VERSION"));
 // Re-export commonly used items
 pub use adapters::ManifestMetadata;
 pub use changeset::{
-    load_changesets, parse_changeset, render_changeset_markdown,
-    render_changeset_markdown_with_tags, ChangesetInfo,
+    ChangesetInfo, load_changesets, parse_changeset, render_changeset_markdown,
+    render_changeset_markdown_with_tags,
 };
 pub use config::Config;
 pub use enrichment::{
-    detect_github_repo_slug, detect_github_repo_slug_with_config, enrich_changeset_message,
-    get_commit_hash_for_path, CommitInfo, GitHubUserInfo,
+    CommitInfo, GitHubUserInfo, detect_github_repo_slug, detect_github_repo_slug_with_config,
+    enrich_changeset_message, get_commit_hash_for_path,
 };
 pub use errors::{Result, SampoError, WorkspaceError};
 pub use filters::{filter_members, list_visible_packages, should_ignore_package, wildcard_match};
 pub use git::current_branch;
 pub use markdown::format_markdown_list_item;
 pub use prerelease::{
-    enter_prerelease, exit_prerelease, restore_preserved_changesets, VersionChange,
+    VersionChange, enter_prerelease, exit_prerelease, restore_preserved_changesets,
 };
 pub use publish::{run_publish, tag_published_crate, topo_order};
 pub use release::{

--- a/crates/sampo/README.md
+++ b/crates/sampo/README.md
@@ -80,7 +80,7 @@ At the root of each published package, a human-readable file listing all changes
 ... previous entries ...
 ```
 
-Sampo generates changelog entries from consumed changesets and enriches them with commit hash links and author acknowledgments (can be disabled in config). 
+Sampo generates changelog entries from consumed changesets and enriches them with commit hash links and author acknowledgments (can be disabled in config).
 
 Any intro content or custom main header before the first `##` section is preserved. You can also manually edit the previously released entries, and Sampo will keep them intact.
 
@@ -163,6 +163,9 @@ linked = [["cargo/pkg-e", "cargo/pkg-f"], ["cargo/pkg-g", "cargo/pkg-h"]]
 `tags`: An optional array of custom changelog section names (default: `[]`). When configured, changesets can use the `bump (Tag)` format to categorize entries under custom headings instead of the default bump-based sections. For example, `tags = ["Added", "Changed", "Deprecated", "Removed", "Fixed", "Security"]` enables [Keep a Changelog](https://keepachangelog.com/) style formatting where `cargo/my-crate: minor (Added)` appears under `### Added` while still applying a minor version bump.
 
 ### `[changelog]` section
+
+> [!WARNING]
+> Commit hash links and author acknowledgments won't work in shallow clones or CI environments where the full git history is not available.
 
 `show_commit_hash`: Whether to include commit hash links in changelog entries (default: `true`). When enabled, changelog entries include clickable commit hash links that point to the commit on GitHub.
 


### PR DESCRIPTION
Changelog entries now correctly credit the original changeset author, even if the file was later edited by someone else.

## What has changed?

- `crates/sampo-core/src/enrichment.rs`: Use `--diff-filter=A` in git log to retrieve the commit that **created** the changeset file, not the last one that modified it.

## How is this tested?

- `crates/sampo-core/src/enrichment.rs`: Two new tests verify that (1) modifications don't change the credited author, and (2) delete/recreate correctly credits the new author.

### How is this documented?

- Added a warning in `crates/sampo/README.md` about shallow clones and CI environments affecting commit hash links and author acknowledgments.