### PR TITLE
feat(cli): enhance exit codes for better CI integration

### DIFF
--- a/.sampo/changesets/valorous-knight-mielikki.md
+++ b/.sampo/changesets/valorous-knight-mielikki.md
@@ -1,0 +1,5 @@
+---
+cargo/sampo: minor
+---
+
+Improve exit codes to easily detect when running a `sampo` command would not apply any changes. This is useful in CI jobs when we don't want to run the whole process if there's no changes to be applied.

--- a/crates/sampo/README.md
+++ b/crates/sampo/README.md
@@ -217,6 +217,47 @@ All commands should be run from the root of the repository:
 
 For detailed command options, use `sampo help <command>` or `sampo <command> --help`.
 
+### Exit codes
+
+Sampo uses standard exit codes to indicate command outcomes, making it easy to integrate with CI/CD pipelines and shell scripts:
+
+| Exit Code | Meaning |
+| --------- | ------- |
+| `0` | Success — changes were made (or would be made with `--dry-run`) |
+| `1` | Error — command failed |
+| `2` | No changes — command succeeded but no action was needed |
+
+Commands that support exit code `2`:
+- `sampo release` — no pending changesets to process
+- `sampo publish` — no packages to publish (already published or no new versions)
+- `sampo pre` — packages already in the target pre-release state
+- `sampo update` — CLI is already at the latest version
+
+This allows you to detect whether changes occurred:
+
+```bash
+sampo release --dry-run
+case $? in
+  0) echo "Pending changesets found" ;;
+  2) echo "No changesets to process" ;;
+  *) echo "Error occurred"; exit 1 ;;
+esac
+```
+
+Or use it directly in conditionals:
+
+```bash
+if sampo release --dry-run; then
+  echo "Changes would be made, proceeding..."
+  sampo release
+elif [ $? -eq 2 ]; then
+  echo "Nothing to release"
+else
+  echo "Release failed"
+  exit 1
+fi
+```
+
 ## Alternatives
 
 Sampo is deeply inspired by [Changesets](https://github.com/changesets/changesets) and [Lerna](https://github.com/lerna/lerna), from which we borrow the changeset format and monorepo release workflows. But our project goes beyond the JavaScript/TypeScript ecosystem, as it is made with Rust, and designed to support multiple mixed ecosystems. Other <abbr title="Node Package Manager">npm</abbr>-limited tools include [Rush](https://github.com/microsoft/rushstack), [Ship.js](https://github.com/algolia/shipjs), [Release It!](https://github.com/release-it/release-it), and [beachball](https://github.com/microsoft/beachball).

--- a/crates/sampo/src/publish.rs
+++ b/crates/sampo/src/publish.rs
@@ -2,8 +2,13 @@ use crate::cli::PublishArgs;
 use sampo_core::errors::Result;
 use sampo_core::run_publish;
 
-pub fn run(args: &PublishArgs) -> Result<()> {
+/// Runs the publish command.
+///
+/// Returns `Ok(true)` if packages were published (or would be in dry-run mode),
+/// `Ok(false)` if there were no packages to publish.
+pub fn run(args: &PublishArgs) -> Result<bool> {
     let cwd = std::env::current_dir()?;
-    run_publish(&cwd, args.dry_run, &args.publish_args)?;
-    Ok(())
+    let output = run_publish(&cwd, args.dry_run, &args.publish_args)?;
+
+    Ok(!output.tags.is_empty())
 }

--- a/crates/sampo/src/release.rs
+++ b/crates/sampo/src/release.rs
@@ -2,9 +2,13 @@ use crate::cli::ReleaseArgs;
 use sampo_core::errors::Result;
 use sampo_core::run_release;
 
-pub fn run(args: &ReleaseArgs) -> Result<()> {
+/// Runs the release command.
+///
+/// Returns `Ok(true)` if changes were made (or would be made in dry-run mode),
+/// `Ok(false)` if there were no changesets to process.
+pub fn run(args: &ReleaseArgs) -> Result<bool> {
     let cwd = std::env::current_dir()?;
-    let _ = run_release(&cwd, args.dry_run)?;
+    let output = run_release(&cwd, args.dry_run)?;
 
-    Ok(())
+    Ok(!output.released_packages.is_empty())
 }

--- a/crates/sampo/src/update.rs
+++ b/crates/sampo/src/update.rs
@@ -14,7 +14,10 @@ const BIN_NAME: &str = "sampo";
 const TAG_PREFIX: &str = "sampo-v";
 
 /// Runs the update command.
-pub fn run(args: &UpdateArgs) -> Result<()> {
+///
+/// Returns `Ok(true)` if an update was performed,
+/// `Ok(false)` if already at latest version or update was cancelled.
+pub fn run(args: &UpdateArgs) -> Result<bool> {
     log_info("Checking for updates...");
 
     let releases = fetch_sampo_releases()?;
@@ -25,7 +28,7 @@ pub fn run(args: &UpdateArgs) -> Result<()> {
 
     if latest_version <= current_version {
         log_success_value("Already up to date", &current_version.to_string());
-        return Ok(());
+        return Ok(false);
     }
 
     log_warning(&format!(
@@ -35,14 +38,14 @@ pub fn run(args: &UpdateArgs) -> Result<()> {
 
     if !args.yes && !confirm_update()? {
         log_info("Update cancelled.");
-        return Ok(());
+        return Ok(false);
     }
 
     log_info("Downloading and installing...");
     perform_update(&latest.name)?;
 
     log_success_value("Updated to version", &latest_version.to_string());
-    Ok(())
+    Ok(true)
 }
 
 /// Fetches all releases from the GitHub repository.


### PR DESCRIPTION
## What has changed?

This update introduces improved exit codes for the `sampo` commands, allowing for easier detection of no-op scenarios. The changes include modifications to the command implementations to return specific exit codes, enhancing usability in CI/CD pipelines. Additionally, the README has been updated to document the new exit codes and their meanings.

## How is it tested?

Existing tests still pass. Not sure if it makes sense to have tests for these?

## How is it documented?

Updated `sampo` README
