### PR TITLE
fix(cargo): resolve workspace package versions

### DIFF
--- a/.sampo/changesets/dashing-runesmith-vainamoinen.md
+++ b/.sampo/changesets/dashing-runesmith-vainamoinen.md
@@ -1,0 +1,7 @@
+---
+cargo/sampo: patch
+cargo/sampo-core: patch
+cargo/sampo-github-action: patch
+---
+
+In Rust (Cargo) projects, fixed version detection for packages using `version.workspace = true`.


### PR DESCRIPTION
Fixes #184 . In Rust (Cargo) projects, fixed version detection for packages using `version.workspace = true`.

## What has changed?

- `crates/sampo-core/src/adapters/cargo.rs`: Added `resolve_package_version` to handle both direct version strings and workspace inheritance, and reject invalid manifests early.

## How is it tested?

- `crates/sampo-core/src/adapters/cargo/cargo_tests.rs`: Integration tests verify `discover_cargo` resolves inherited versions and rejects missing `workspace.package.version` with a clear error.

## How is it documented?

Self-documenting code; no external documentation needed.