### PR TITLE
fix(core): resolve package manager on windows

### DIFF
--- a/.sampo/changesets/bold-knight-lintu.md
+++ b/.sampo/changesets/bold-knight-lintu.md
@@ -1,0 +1,5 @@
+---
+cargo/sampo-core: patch
+---
+
+Fixed publish command failing on Windows when package managers (npm, pnpm, yarn, composer, mix) are installed as .cmd/.bat scripts.

--- a/crates/sampo-core/src/adapters/packagist.rs
+++ b/crates/sampo-core/src/adapters/packagist.rs
@@ -1,4 +1,5 @@
 use crate::errors::{Result, SampoError, WorkspaceError};
+use crate::process::command;
 use crate::types::{PackageInfo, PackageKind};
 use reqwest::StatusCode;
 use reqwest::blocking::Client;
@@ -222,7 +223,7 @@ impl PackagistAdapter {
 
         // Packagist is VCS-based: it auto-updates when you push git tags.
         // The "publish" step validates the package structure.
-        let mut cmd = Command::new("composer");
+        let mut cmd = command("composer");
         cmd.current_dir(manifest_dir);
         cmd.arg("validate");
 
@@ -278,7 +279,7 @@ impl PackagistAdapter {
 
         println!("Regenerating composer.lock…");
 
-        let mut cmd = Command::new("composer");
+        let mut cmd = command("composer");
         cmd.arg("update").arg("--lock").current_dir(workspace_root);
 
         println!("Running: {}", format_command_display(&cmd));

--- a/crates/sampo-core/src/lib.rs
+++ b/crates/sampo-core/src/lib.rs
@@ -7,6 +7,7 @@ pub mod filters;
 pub mod git;
 pub mod markdown;
 pub mod prerelease;
+pub mod process;
 pub mod publish;
 pub mod release;
 pub mod types;

--- a/crates/sampo-core/src/process.rs
+++ b/crates/sampo-core/src/process.rs
@@ -1,0 +1,37 @@
+use std::process::Command;
+
+/// Creates a `Command` that can resolve `.cmd` and `.bat` scripts on Windows.
+///
+/// On Windows, tools like npm, pnpm, yarn, composer, and mix are installed
+/// as `.cmd`/`.bat` batch scripts. Rust's `std::process::Command` only
+/// auto-resolves `.exe` extensions, not `.cmd`/`.bat` (see rust-lang/rust#37519).
+/// This function wraps the invocation through `cmd.exe /C` on Windows
+/// to ensure proper resolution via PATHEXT.
+pub fn command(program: &str) -> Command {
+    if cfg!(windows) {
+        let mut cmd = Command::new("cmd");
+        cmd.args(["/C", program]);
+        cmd
+    } else {
+        Command::new(program)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn command_creates_valid_command() {
+        let cmd = command("test-program");
+
+        if cfg!(windows) {
+            assert_eq!(cmd.get_program(), "cmd");
+            let args: Vec<_> = cmd.get_args().collect();
+            assert_eq!(args, ["/C", "test-program"]);
+        } else {
+            assert_eq!(cmd.get_program(), "test-program");
+            assert_eq!(cmd.get_args().count(), 0);
+        }
+    }
+}


### PR DESCRIPTION
Closes #196 . Fixed publish command failing on Windows when package managers (npm, pnpm, yarn, composer, mix) are installed as .cmd/.bat scripts.

## What has changed?

- `crates/sampo-core/src/process.rs`: New `command()` helper that wraps invocations through `cmd.exe /C` on Windows to resolve `.cmd`/`.bat` scripts; transparent pass-through on other platforms.
- `crates/sampo-core/src/adapters/npm.rs` , `crates/sampo-core/src/adapters/packagist.rs` , `crates/sampo-core/src/adapters/hex/mix.rs`: Replaced `Command::new(...)` with `command(...)` .

## How is it tested?

- `crates/sampo-core/src/process.rs`: Unit test asserting correct command construction via `get_program()`/`get_args()`.
- Full Windows validation will need an E2E test suite for each OS... TODO.

## How is it documented?

Expected behaviour.