### PR TITLE
fix(core): adjust prerelease entry bumps and preservation

### DIFF
--- a/.sampo/changesets/forthright-lord-ahti.md
+++ b/.sampo/changesets/forthright-lord-ahti.md
@@ -2,4 +2,4 @@
 cargo/sampo-core: patch
 ---
 
-Prereleases now advance the base version before incrementing prerelease counters and only preserve prerelease-targeted changesets.
+Fixed prerelease versioning to advance the base version before incrementing prerelease counters, and to only preserve prerelease-targeted changesets.

--- a/.sampo/changesets/forthright-lord-ahti.md
+++ b/.sampo/changesets/forthright-lord-ahti.md
@@ -1,0 +1,5 @@
+---
+cargo/sampo-core: patch
+---
+
+Fixed In Rust (cargo) projects, prerelease releases now advance the base version before incrementing prerelease counters and only preserve prerelease-targeted changesets.

--- a/.sampo/changesets/forthright-lord-ahti.md
+++ b/.sampo/changesets/forthright-lord-ahti.md
@@ -2,4 +2,4 @@
 cargo/sampo-core: patch
 ---
 
-Fixed In Rust (cargo) projects, prerelease releases now advance the base version before incrementing prerelease counters and only preserve prerelease-targeted changesets.
+Prereleases now advance the base version before incrementing prerelease counters and only preserve prerelease-targeted changesets.

--- a/crates/sampo-core/src/release.rs
+++ b/crates/sampo-core/src/release.rs
@@ -493,7 +493,17 @@ pub fn run_release(root: &std::path::Path, dry_run: bool) -> Result<ReleaseOutpu
 
     let current_changesets = load_changesets(&changesets_dir, &config.changesets_tags)?;
     let preserved_changesets = load_changesets(&prerelease_dir, &config.changesets_tags)?;
-    let preserved_targets = collect_preserved_targets(&preserved_changesets, &workspace)?;
+    let preserved_targets = match collect_preserved_targets(&preserved_changesets, &workspace) {
+        Ok(targets) => targets,
+        Err(err) => {
+            eprintln!(
+                "Warning: failed to resolve some preserved changesets in {}: {}",
+                prerelease_dir.display(),
+                err
+            );
+            Vec::new()
+        }
+    };
 
     let mut using_preserved = false;
     let mut cached_plan_state: Option<PlanState> = None;

--- a/crates/sampo-core/src/release.rs
+++ b/crates/sampo-core/src/release.rs
@@ -1388,7 +1388,7 @@ fn prepare_release_plan(
                     if should_bump_prerelease_base(&parsed, identifier, preserved_targets) {
                         bump_prerelease_entry(&parsed, *bump).unwrap_or_else(|_| old.clone())
                     } else {
-                        bump_version(&old, *bump).unwrap_or_else(|_| old.clone())
+                        bump_version_from_parsed(&parsed, *bump).unwrap_or_else(|_| old.clone())
                     }
                 }
                 Err(_) => old.clone(),
@@ -1810,9 +1810,11 @@ fn bump_prerelease_entry(version: &Version, bump: Bump) -> std::result::Result<S
     Ok(updated.to_string())
 }
 
-/// Bump a semver version string, including pre-release handling
-pub fn bump_version(old: &str, bump: Bump) -> std::result::Result<String, String> {
-    let mut version = parse_version_string(old)?;
+fn bump_version_from_parsed(
+    parsed: &Version,
+    bump: Bump,
+) -> std::result::Result<String, String> {
+    let mut version = parsed.clone();
     let original_pre = version.pre.clone();
 
     if original_pre.is_empty() {
@@ -1828,15 +1830,28 @@ pub fn bump_version(old: &str, bump: Bump) -> std::result::Result<String, String
         Ok(version.to_string())
     } else {
         let base_pre = strip_trailing_numeric_identifiers(&original_pre).ok_or_else(|| {
-            format!(
-                "Pre-release version '{old}' must include a non-numeric identifier before the counter"
-            )
+            "Pre-release version must include a non-numeric identifier before the counter"
+                .to_string()
         })?;
 
         apply_base_bump(&mut version, bump)?;
         version.pre = base_pre;
         Ok(version.to_string())
     }
+}
+
+/// Bump a semver version string, including pre-release handling
+pub fn bump_version(old: &str, bump: Bump) -> std::result::Result<String, String> {
+    let version = parse_version_string(old)?;
+    bump_version_from_parsed(&version, bump).map_err(|err| {
+        if err.contains("Pre-release version must include a non-numeric identifier") {
+            format!(
+                "Pre-release version '{old}' must include a non-numeric identifier before the counter"
+            )
+        } else {
+            err
+        }
+    })
 }
 
 fn split_intro_and_versions(body: &str) -> (&str, &str) {

--- a/crates/sampo-core/src/release.rs
+++ b/crates/sampo-core/src/release.rs
@@ -493,6 +493,7 @@ pub fn run_release(root: &std::path::Path, dry_run: bool) -> Result<ReleaseOutpu
 
     let current_changesets = load_changesets(&changesets_dir, &config.changesets_tags)?;
     let preserved_changesets = load_changesets(&prerelease_dir, &config.changesets_tags)?;
+    let preserved_targets = collect_preserved_targets(&preserved_changesets, &workspace)?;
 
     let mut using_preserved = false;
     let mut cached_plan_state: Option<PlanState> = None;
@@ -522,7 +523,7 @@ pub fn run_release(root: &std::path::Path, dry_run: bool) -> Result<ReleaseOutpu
 
         using_preserved = true;
     } else {
-        match compute_plan_state(&current_changesets, &workspace, &config)? {
+        match compute_plan_state(&current_changesets, &workspace, &config, &preserved_targets)? {
             PlanOutcome::Plan(plan) => {
                 let is_prerelease_preview = releases_include_prerelease(&plan.releases);
                 if !is_prerelease_preview && !preserved_changesets.is_empty() {
@@ -570,7 +571,7 @@ pub fn run_release(root: &std::path::Path, dry_run: bool) -> Result<ReleaseOutpu
             final_changesets = load_changesets(&changesets_dir, &config.changesets_tags)?;
         }
 
-        match compute_plan_state(&final_changesets, &workspace, &config)? {
+        match compute_plan_state(&final_changesets, &workspace, &config, &preserved_targets)? {
             PlanOutcome::Plan(plan) => plan,
             PlanOutcome::NoApplicablePackages => {
                 println!("No applicable packages found in changesets.");
@@ -591,7 +592,7 @@ pub fn run_release(root: &std::path::Path, dry_run: bool) -> Result<ReleaseOutpu
         final_changesets = current_changesets;
         match cached_plan_state {
             Some(plan) => plan,
-            None => match compute_plan_state(&final_changesets, &workspace, &config)? {
+            None => match compute_plan_state(&final_changesets, &workspace, &config, &preserved_targets)? {
                 PlanOutcome::Plan(plan) => plan,
                 PlanOutcome::NoApplicablePackages => {
                     println!("No applicable packages found in changesets.");
@@ -638,7 +639,15 @@ pub fn run_release(root: &std::path::Path, dry_run: bool) -> Result<ReleaseOutpu
         &config,
     )?;
 
-    finalize_consumed_changesets(used_paths, &workspace.root, is_prerelease_release)?;
+    let prerelease_targets = collect_prerelease_targets(&releases);
+    finalize_consumed_changesets(
+        used_paths,
+        &workspace.root,
+        is_prerelease_release,
+        &final_changesets,
+        &workspace,
+        &prerelease_targets,
+    )?;
 
     // Regenerate lockfiles for all ecosystems present in the workspace.
     // This ensures the release branch includes consistent, up-to-date lockfiles
@@ -657,6 +666,7 @@ fn compute_plan_state(
     changesets: &[ChangesetInfo],
     workspace: &Workspace,
     config: &Config,
+    preserved_targets: &BTreeSet<String>,
 ) -> Result<PlanOutcome> {
     let (mut bump_by_pkg, messages_by_pkg, used_paths) =
         compute_initial_bumps(changesets, workspace, config)?;
@@ -669,7 +679,7 @@ fn compute_plan_state(
     apply_dependency_cascade(&mut bump_by_pkg, &dependents, config, workspace)?;
     apply_linked_dependencies(&mut bump_by_pkg, config, workspace)?;
 
-    let releases = prepare_release_plan(&bump_by_pkg, workspace)?;
+    let releases = prepare_release_plan(&bump_by_pkg, workspace, preserved_targets)?;
     if releases.is_empty() {
         return Ok(PlanOutcome::NoMatchingCrates);
     }
@@ -708,6 +718,19 @@ fn releases_include_prerelease(releases: &ReleasePlan) -> bool {
     })
 }
 
+fn collect_prerelease_targets(releases: &ReleasePlan) -> BTreeSet<String> {
+    let mut targets = BTreeSet::new();
+    for (identifier, _, new_version) in releases {
+        if Version::parse(new_version)
+            .map(|v| !v.pre.is_empty())
+            .unwrap_or(false)
+        {
+            targets.insert(identifier.clone());
+        }
+    }
+    targets
+}
+
 fn is_spec_in_prerelease(workspace: &Workspace, spec: &PackageSpecifier) -> Result<bool> {
     let info = resolve_package_spec(workspace, spec)?;
 
@@ -740,6 +763,20 @@ fn all_preserved_targets_in_prerelease(
         }
     }
     Ok(true)
+}
+
+fn collect_preserved_targets(
+    changesets: &[ChangesetInfo],
+    workspace: &Workspace,
+) -> Result<BTreeSet<String>> {
+    let mut targets = BTreeSet::new();
+    for changeset in changesets {
+        for (spec, _, _) in &changeset.entries {
+            let info = resolve_package_spec(workspace, spec)?;
+            targets.insert(info.canonical_identifier().to_string());
+        }
+    }
+    Ok(targets)
 }
 
 /// Move all preserved changeset files from the prerelease directory to the
@@ -874,6 +911,9 @@ fn finalize_consumed_changesets(
     used_paths: BTreeSet<PathBuf>,
     workspace_root: &Path,
     preserve_for_prerelease: bool,
+    changesets: &[ChangesetInfo],
+    workspace: &Workspace,
+    prerelease_targets: &BTreeSet<String>,
 ) -> Result<()> {
     if used_paths.is_empty() {
         return Ok(());
@@ -881,11 +921,51 @@ fn finalize_consumed_changesets(
 
     if preserve_for_prerelease {
         let prerelease_dir = workspace_root.join(".sampo").join("prerelease");
+        let mut by_path: BTreeMap<&Path, &ChangesetInfo> = BTreeMap::new();
+        for changeset in changesets {
+            by_path.insert(changeset.path.as_path(), changeset);
+        }
         for path in used_paths {
             if !path.exists() {
                 continue;
             }
-            let _ = move_changeset_file(&path, &prerelease_dir)?;
+            if let Some(changeset) = by_path.get(path.as_path()) {
+                let mut prerelease_entries = Vec::new();
+                for entry in &changeset.entries {
+                    let info = resolve_package_spec(workspace, &entry.0)?;
+                    if prerelease_targets.contains(info.canonical_identifier()) {
+                        prerelease_entries.push(entry.clone());
+                    }
+                }
+
+                if prerelease_entries.is_empty() {
+                    fs::remove_file(&path)
+                        .map_err(|err| SampoError::Io(io_error_with_path(err, &path)))?;
+                    continue;
+                }
+
+                if prerelease_entries.len() == changeset.entries.len() {
+                    let _ = move_changeset_file(&path, &prerelease_dir)?;
+                    continue;
+                }
+
+                fs::create_dir_all(&prerelease_dir)?;
+                let file_name = path
+                    .file_name()
+                    .ok_or_else(|| SampoError::Changeset("Invalid changeset file name".to_string()))?;
+                let mut destination = prerelease_dir.join(file_name);
+                if destination.exists() {
+                    destination = unique_destination_path(&prerelease_dir, file_name);
+                }
+                let preserved_content =
+                    render_changeset_markdown_with_tags(&prerelease_entries, &changeset.message);
+                fs::write(&destination, preserved_content)
+                    .map_err(|err| SampoError::Io(io_error_with_path(err, &destination)))?;
+                fs::remove_file(&path)
+                    .map_err(|err| SampoError::Io(io_error_with_path(err, &path)))?;
+            } else {
+                let _ = move_changeset_file(&path, &prerelease_dir)?;
+            }
         }
         println!("Preserved consumed changesets for pre-release.");
     } else {
@@ -1271,6 +1351,7 @@ fn apply_linked_dependencies(
 fn prepare_release_plan(
     bump_by_pkg: &BTreeMap<String, Bump>,
     ws: &Workspace,
+    preserved_targets: &BTreeSet<String>,
 ) -> Result<ReleasePlan> {
     // Map package identifier -> PackageInfo for quick lookup
     let mut by_id: BTreeMap<String, &PackageInfo> = BTreeMap::new();
@@ -1287,7 +1368,16 @@ fn prepare_release_plan(
                 info.version.clone()
             };
 
-            let newv = bump_version(&old, *bump).unwrap_or_else(|_| old.clone());
+            let newv = match parse_version_string(&old) {
+                Ok(parsed) => {
+                    if should_bump_prerelease_base(&parsed, identifier, preserved_targets) {
+                        bump_prerelease_entry(&parsed, *bump).unwrap_or_else(|_| old.clone())
+                    } else {
+                        bump_version(&old, *bump).unwrap_or_else(|_| old.clone())
+                    }
+                }
+                Err(_) => old.clone(),
+            };
 
             releases.push((identifier.clone(), old, newv));
         }
@@ -1639,6 +1729,14 @@ fn strip_trailing_numeric_identifiers(pre: &Prerelease) -> Option<Prerelease> {
     }
 }
 
+fn prerelease_has_trailing_numeric(pre: &Prerelease) -> bool {
+    pre.as_str()
+        .split('.')
+        .last()
+        .map(|part| part.chars().all(|ch| ch.is_ascii_digit()))
+        .unwrap_or(false)
+}
+
 fn apply_base_bump(version: &mut Version, bump: Bump) -> std::result::Result<(), String> {
     match bump {
         Bump::Patch => {
@@ -1666,6 +1764,35 @@ fn apply_base_bump(version: &mut Version, bump: Bump) -> std::result::Result<(),
     version.pre = Prerelease::EMPTY;
     version.build = BuildMetadata::EMPTY;
     Ok(())
+}
+
+fn should_bump_prerelease_base(
+    version: &Version,
+    identifier: &str,
+    preserved_targets: &BTreeSet<String>,
+) -> bool {
+    if version.pre.is_empty() {
+        return false;
+    }
+    if preserved_targets.contains(identifier) {
+        return false;
+    }
+    !prerelease_has_trailing_numeric(&version.pre)
+}
+
+fn bump_prerelease_entry(version: &Version, bump: Bump) -> std::result::Result<String, String> {
+    if version.pre.is_empty() {
+        return Err("Version does not contain a pre-release identifier".to_string());
+    }
+
+    let base_pre = strip_trailing_numeric_identifiers(&version.pre).ok_or_else(|| {
+        "Pre-release version must include a non-numeric identifier before the counter".to_string()
+    })?;
+
+    let mut updated = version.clone();
+    apply_base_bump(&mut updated, bump)?;
+    updated.pre = base_pre;
+    Ok(updated.to_string())
 }
 
 /// Bump a semver version string, including pre-release handling

--- a/crates/sampo-core/src/release.rs
+++ b/crates/sampo-core/src/release.rs
@@ -493,17 +493,7 @@ pub fn run_release(root: &std::path::Path, dry_run: bool) -> Result<ReleaseOutpu
 
     let current_changesets = load_changesets(&changesets_dir, &config.changesets_tags)?;
     let preserved_changesets = load_changesets(&prerelease_dir, &config.changesets_tags)?;
-    let preserved_targets = match collect_preserved_targets(&preserved_changesets, &workspace) {
-        Ok(targets) => targets,
-        Err(err) => {
-            eprintln!(
-                "Warning: failed to resolve some preserved changesets in {}: {}",
-                prerelease_dir.display(),
-                err
-            );
-            BTreeSet::new()
-        }
-    };
+    let preserved_targets = collect_preserved_targets(&preserved_changesets, &workspace)?;
 
     let mut using_preserved = false;
     let mut cached_plan_state: Option<PlanState> = None;

--- a/crates/sampo-core/src/release.rs
+++ b/crates/sampo-core/src/release.rs
@@ -1732,7 +1732,7 @@ fn strip_trailing_numeric_identifiers(pre: &Prerelease) -> Option<Prerelease> {
 fn prerelease_has_trailing_numeric(pre: &Prerelease) -> bool {
     pre.as_str()
         .split('.')
-        .last()
+        .next_back()
         .map(|part| part.chars().all(|ch| ch.is_ascii_digit()))
         .unwrap_or(false)
 }

--- a/crates/sampo-core/src/release.rs
+++ b/crates/sampo-core/src/release.rs
@@ -501,7 +501,7 @@ pub fn run_release(root: &std::path::Path, dry_run: bool) -> Result<ReleaseOutpu
                 prerelease_dir.display(),
                 err
             );
-            Vec::new()
+            BTreeSet::new()
         }
     };
 
@@ -602,7 +602,12 @@ pub fn run_release(root: &std::path::Path, dry_run: bool) -> Result<ReleaseOutpu
         final_changesets = current_changesets;
         match cached_plan_state {
             Some(plan) => plan,
-            None => match compute_plan_state(&final_changesets, &workspace, &config, &preserved_targets)? {
+            None => match compute_plan_state(
+                &final_changesets,
+                &workspace,
+                &config,
+                &preserved_targets,
+            )? {
                 PlanOutcome::Plan(plan) => plan,
                 PlanOutcome::NoApplicablePackages => {
                     println!("No applicable packages found in changesets.");
@@ -960,9 +965,9 @@ fn finalize_consumed_changesets(
                 }
 
                 fs::create_dir_all(&prerelease_dir)?;
-                let file_name = path
-                    .file_name()
-                    .ok_or_else(|| SampoError::Changeset("Invalid changeset file name".to_string()))?;
+                let file_name = path.file_name().ok_or_else(|| {
+                    SampoError::Changeset("Invalid changeset file name".to_string())
+                })?;
                 let mut destination = prerelease_dir.join(file_name);
                 if destination.exists() {
                     destination = unique_destination_path(&prerelease_dir, file_name);

--- a/crates/sampo-core/src/release_tests.rs
+++ b/crates/sampo-core/src/release_tests.rs
@@ -622,7 +622,7 @@ mod tests {
             .expect("first release should succeed");
         assert_eq!(output.released_packages.len(), 1);
         assert_eq!(output.released_packages[0].name, "pkg1");
-        workspace.assert_crate_version("pkg1", "1.0.0-alpha.1");
+        workspace.assert_crate_version("pkg1", "1.1.0-alpha");
 
         let prerelease_dir = workspace.root.join(".sampo/prerelease");
         assert!(prerelease_dir.exists());
@@ -634,9 +634,58 @@ mod tests {
             .expect("second release should succeed");
         assert_eq!(output.released_packages.len(), 1);
         assert_eq!(output.released_packages[0].name, "pkg1");
-        workspace.assert_crate_version("pkg1", "1.0.0-alpha.2");
+        workspace.assert_crate_version("pkg1", "1.1.0-alpha.1");
         workspace.assert_crate_version("pkg2", "1.0.0");
         workspace.assert_crate_version("pkg3", "1.0.0");
+    }
+
+    #[test]
+    fn prerelease_mixed_changesets_only_preserve_prerelease_entries() {
+        let mut workspace = TestWorkspace::new();
+        workspace.add_crate("pkg1", "1.0.0-alpha");
+        workspace.add_crate("pkg2", "1.0.0");
+        workspace.add_changeset(&["pkg1"], Bump::Minor, "feat: prerelease change");
+        workspace.add_changeset(&["pkg2"], Bump::Patch, "fix: stable change");
+
+        let output = workspace
+            .run_release(false)
+            .expect("release should succeed");
+        assert_eq!(output.released_packages.len(), 2);
+        workspace.assert_crate_version("pkg1", "1.1.0-alpha");
+        workspace.assert_crate_version("pkg2", "1.0.1");
+
+        let changesets_dir = workspace.root.join(".sampo/changesets");
+        let pending = fs::read_dir(&changesets_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().is_file())
+            .collect::<Vec<_>>();
+        assert!(pending.is_empty(), "changesets directory should be empty");
+
+        let prerelease_dir = workspace.root.join(".sampo/prerelease");
+        let preserved = fs::read_dir(&prerelease_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().is_file())
+            .collect::<Vec<_>>();
+        assert_eq!(preserved.len(), 1);
+
+        let preserved_text = fs::read_to_string(preserved[0].path()).unwrap();
+        assert!(preserved_text.contains("pkg1"));
+        assert!(!preserved_text.contains("pkg2"));
+    }
+
+    #[test]
+    fn prerelease_entry_bumps_base_before_counter() {
+        let mut workspace = TestWorkspace::new();
+        workspace.add_crate("pkg1", "1.2.3-alpha");
+        workspace.add_changeset(&["pkg1"], Bump::Patch, "fix: prerelease patch");
+
+        workspace
+            .run_release(false)
+            .expect("entry prerelease release should succeed");
+
+        workspace.assert_crate_version("pkg1", "1.2.4-alpha");
     }
 
     #[test]
@@ -650,7 +699,7 @@ mod tests {
         workspace
             .run_release(false)
             .expect("prerelease should succeed");
-        workspace.assert_crate_version("pkg1", "1.0.0-alpha.1");
+        workspace.assert_crate_version("pkg1", "1.1.0-alpha");
 
         let prerelease_dir = workspace.root.join(".sampo/prerelease");
         assert!(prerelease_dir.exists());
@@ -702,7 +751,7 @@ mod tests {
             .run_release(false)
             .expect("initial alpha pre-release should succeed");
 
-        workspace.assert_crate_version("foo", "1.0.0-alpha.1");
+        workspace.assert_crate_version("foo", "1.1.0-alpha");
 
         let packages = vec![String::from("foo")];
         let exit_updates = exit_prerelease(&workspace.root, &packages).unwrap();
@@ -717,7 +766,7 @@ mod tests {
             .run_release(false)
             .expect("beta pre-release should succeed");
 
-        workspace.assert_crate_version("foo", "1.0.0-beta.1");
+        workspace.assert_crate_version("foo", "1.2.0-beta");
 
         let changelog_path = workspace
             .crates
@@ -727,7 +776,7 @@ mod tests {
         let changelog = fs::read_to_string(changelog_path).expect("changelog to exist");
 
         assert!(
-            changelog.contains("## 1.0.0-beta.1"),
+            changelog.contains("## 1.2.0-beta"),
             "expected changelog to include beta entry"
         );
         assert!(

--- a/crates/sampo/README.md
+++ b/crates/sampo/README.md
@@ -42,7 +42,7 @@ Sampo enforces [Semantic Versioning](https://semver.org/) (SemVer) to indicate t
 
 For example, a user can safely update from version `1.2.3` to `1.2.4` (patch) or `1.3.0` (minor), but should review changes before updating to `2.0.0` (major).
 
-Pre-release versions are supported using [SemVer §9](https://semver.org/#spec-item-9) conventions (e.g., `1.0.0-alpha`, `2.1.0-beta.2`, `3.0.0-rc.5`, etc). While a pre-release stays within its implied level (patch for `x.y.z-prerelease`, minor for `x.y.0-prerelease`, major for `x.0.0-prerelease`), we only bump the numeric suffix (`alpha` → `alpha.1` → `alpha.2` → etc). If a higher bump is required, the base version advances and the numeric suffix is reset (`1.8.0-alpha.2` + major → `2.0.0-alpha`).
+Pre-release versions are supported using [SemVer §9](https://semver.org/#spec-item-9) conventions (e.g., `1.0.0-alpha`, `2.1.0-beta.2`, `3.0.0-rc.5`, etc). On the first pre-release release after entering pre mode, Sampo advances the base version according to the pending changeset bump so pre-releases stay ahead of the latest stable version (for example, `1.2.3-alpha` + patch → `1.2.4-alpha`). After that, while a pre-release stays within its implied level (patch for `x.y.z-prerelease`, minor for `x.y.0-prerelease`, major for `x.0.0-prerelease`), we only bump the numeric suffix (`alpha` → `alpha.1` → `alpha.2` → etc). If a higher bump is required, the base version advances and the numeric suffix is reset (`1.8.0-alpha.2` + major → `2.0.0-alpha`).
 
 #### Changesets
 

--- a/crates/sampo/README.md
+++ b/crates/sampo/README.md
@@ -42,7 +42,7 @@ Sampo enforces [Semantic Versioning](https://semver.org/) (SemVer) to indicate t
 
 For example, a user can safely update from version `1.2.3` to `1.2.4` (patch) or `1.3.0` (minor), but should review changes before updating to `2.0.0` (major).
 
-Pre-release versions are supported using [SemVer §9](https://semver.org/#spec-item-9) conventions (e.g., `1.0.0-alpha`, `2.1.0-beta.2`, `3.0.0-rc.5`, etc). On the first pre-release release after entering pre mode, Sampo advances the base version according to the pending changeset bump so pre-releases stay ahead of the latest stable version (for example, `1.2.3-alpha` + patch → `1.2.4-alpha`). After that, while a pre-release stays within its implied level (patch for `x.y.z-prerelease`, minor for `x.y.0-prerelease`, major for `x.0.0-prerelease`), we only bump the numeric suffix (`alpha` → `alpha.1` → `alpha.2` → etc). If a higher bump is required, the base version advances and the numeric suffix is reset (`1.8.0-alpha.2` + major → `2.0.0-alpha`).
+Pre-release versions are supported using [SemVer §9](https://semver.org/#spec-item-9) conventions (e.g., `1.0.0-alpha`, `2.1.0-beta.2`, `3.0.0-rc.5`, etc). For the first pre-release after entering pre mode, Sampo advances the base version according to the pending changeset bump so pre-releases stay ahead of the latest stable version (for example, `1.2.3-alpha` + patch → `1.2.4-alpha`). After that, while a pre-release stays within its implied level (patch for `x.y.z-prerelease`, minor for `x.y.0-prerelease`, major for `x.0.0-prerelease`), we only bump the numeric suffix (`alpha` → `alpha.1` → `alpha.2` → etc). If a higher bump is required, the base version advances and the numeric suffix is reset (`1.8.0-alpha.2` + major → `2.0.0-alpha`).
 
 #### Changesets
 


### PR DESCRIPTION
## What has changed?

- Adjusted prerelease entry bumping in `crates/sampo-core/src/release.rs` so entry bumps advance the base version and only prerelease-targeted changesets are preserved.
- Added regression tests in `crates/sampo-core/src/release_tests.rs` for mixed prerelease/stable changesets and entry bump behavior.
- Updated prerelease behavior documentation in `crates/sampo/README.md`.
- Added a changeset in `.sampo/changesets/prerelease-base-bump.md`.

Previously versions went from `1.0.0` to an alpha(`1.0.0-alpha`), and when you added a changeset e.g. minor it would go to `1.0.0-alpha.1` instead of to `1.0.1-alpha` which means that the order of semantic versioning was not being followed.

## How is it tested?

Tests updated/added:
- Added `prerelease_mixed_changesets_only_preserve_prerelease_entries` in `crates/sampo-core/src/release_tests.rs`
- Updated `prerelease_second_changeset_bumps_again` in `crates/sampo-core/src/release_tests.rs`
- Updated `new_stable_changeset_with_preserved_prerelease_changesets` in `crates/sampo-core/src/release_tests.rs`
- Updated `switching_prerelease_label_restores_changesets` in `crates/sampo-core/src/release_tests.rs`
- Added `prerelease_entry_bumps_base_before_counter` in `crates/sampo-core/src/release_tests.rs`

Manual verification:
- Ran `sampo release --dry-run`

## How is it documented?

Updated prerelease behavior description in `crates/sampo/README.md`.