### PR TITLE
fix(core,github-action): stabilize version computation and PR creation

### DIFF
--- a/.sampo/changesets/virtuous-lord-vellamo.md
+++ b/.sampo/changesets/virtuous-lord-vellamo.md
@@ -1,0 +1,6 @@
+---
+cargo/sampo-core: patch
+cargo/sampo-github-action: patch
+---
+
+Fixed incorrect stable version computation when stabilizing a prerelease package (e.g. `0.2.7-alpha.6` + patch now correctly produces `0.2.7` instead of `0.2.8`), and fixed the stabilize PR not being created after merging a prerelease PR when all preserved changesets target packages still in prerelease.

--- a/crates/sampo-core/src/lib.rs
+++ b/crates/sampo-core/src/lib.rs
@@ -38,7 +38,7 @@ pub use release::{
     build_dependency_updates, bump_version, create_dependency_update_entry,
     create_fixed_dependency_policy_entry, detect_all_dependency_explanations,
     detect_fixed_dependency_policy_packages, format_dependency_updates_message,
-    infer_bump_from_versions, run_release,
+    infer_bump_from_versions, run_release, run_stabilize_release,
 };
 pub use types::{
     Bump, ChangelogCategory, DependencyUpdate, PackageInfo, PackageKind, ParsedChangeType,

--- a/crates/sampo-core/src/release.rs
+++ b/crates/sampo-core/src/release.rs
@@ -523,7 +523,13 @@ pub fn run_release(root: &std::path::Path, dry_run: bool) -> Result<ReleaseOutpu
 
         using_preserved = true;
     } else {
-        match compute_plan_state(&current_changesets, &workspace, &config, &preserved_targets, false)? {
+        match compute_plan_state(
+            &current_changesets,
+            &workspace,
+            &config,
+            &preserved_targets,
+            false,
+        )? {
             PlanOutcome::Plan(plan) => {
                 let is_prerelease_preview = releases_include_prerelease(&plan.releases);
                 if !is_prerelease_preview && !preserved_changesets.is_empty() {
@@ -571,7 +577,13 @@ pub fn run_release(root: &std::path::Path, dry_run: bool) -> Result<ReleaseOutpu
             final_changesets = load_changesets(&changesets_dir, &config.changesets_tags)?;
         }
 
-        match compute_plan_state(&final_changesets, &workspace, &config, &preserved_targets, false)? {
+        match compute_plan_state(
+            &final_changesets,
+            &workspace,
+            &config,
+            &preserved_targets,
+            false,
+        )? {
             PlanOutcome::Plan(plan) => plan,
             PlanOutcome::NoApplicablePackages => {
                 println!("No applicable packages found in changesets.");

--- a/crates/sampo-core/src/release.rs
+++ b/crates/sampo-core/src/release.rs
@@ -523,7 +523,7 @@ pub fn run_release(root: &std::path::Path, dry_run: bool) -> Result<ReleaseOutpu
 
         using_preserved = true;
     } else {
-        match compute_plan_state(&current_changesets, &workspace, &config, &preserved_targets)? {
+        match compute_plan_state(&current_changesets, &workspace, &config, &preserved_targets, false)? {
             PlanOutcome::Plan(plan) => {
                 let is_prerelease_preview = releases_include_prerelease(&plan.releases);
                 if !is_prerelease_preview && !preserved_changesets.is_empty() {
@@ -571,7 +571,7 @@ pub fn run_release(root: &std::path::Path, dry_run: bool) -> Result<ReleaseOutpu
             final_changesets = load_changesets(&changesets_dir, &config.changesets_tags)?;
         }
 
-        match compute_plan_state(&final_changesets, &workspace, &config, &preserved_targets)? {
+        match compute_plan_state(&final_changesets, &workspace, &config, &preserved_targets, false)? {
             PlanOutcome::Plan(plan) => plan,
             PlanOutcome::NoApplicablePackages => {
                 println!("No applicable packages found in changesets.");
@@ -597,6 +597,7 @@ pub fn run_release(root: &std::path::Path, dry_run: bool) -> Result<ReleaseOutpu
                 &workspace,
                 &config,
                 &preserved_targets,
+                false,
             )? {
                 PlanOutcome::Plan(plan) => plan,
                 PlanOutcome::NoApplicablePackages => {
@@ -667,11 +668,135 @@ pub fn run_release(root: &std::path::Path, dry_run: bool) -> Result<ReleaseOutpu
     })
 }
 
+/// Stabilize prerelease packages in the workspace, producing stable version numbers
+pub fn run_stabilize_release(root: &Path, dry_run: bool) -> Result<ReleaseOutput> {
+    let workspace = discover_workspace(root)?;
+    let config = Config::load(&workspace.root)?;
+
+    let branch = current_branch()?;
+    if !config.is_release_branch(&branch) {
+        return Err(SampoError::Release(format!(
+            "Branch '{}' is not configured for releases (allowed: {:?})",
+            branch,
+            config.release_branches().into_iter().collect::<Vec<_>>()
+        )));
+    }
+
+    validate_fixed_dependencies(&config, &workspace)?;
+
+    let changesets_dir = workspace.root.join(".sampo").join("changesets");
+    let prerelease_dir = workspace.root.join(".sampo").join("prerelease");
+
+    let current_changesets = load_changesets(&changesets_dir, &config.changesets_tags)?;
+    let preserved_changesets = load_changesets(&prerelease_dir, &config.changesets_tags)?;
+    let preserved_targets = collect_preserved_targets(&preserved_changesets, &workspace)?;
+
+    if current_changesets.is_empty() && preserved_changesets.is_empty() {
+        println!(
+            "No changesets found in {}",
+            workspace.root.join(".sampo").join("changesets").display()
+        );
+        return Ok(ReleaseOutput {
+            released_packages: vec![],
+            dry_run,
+        });
+    }
+
+    // Always restore all preserved changesets — unlike a normal release, which skips preserved
+    // changesets when every target is still in prerelease, stabilization always needs them.
+    let final_changesets = if current_changesets.is_empty() {
+        if dry_run {
+            preserved_changesets
+        } else {
+            restore_prerelease_changesets(&prerelease_dir, &changesets_dir)?;
+            load_changesets(&changesets_dir, &config.changesets_tags)?
+        }
+    } else {
+        if dry_run {
+            let mut all = current_changesets;
+            all.extend(preserved_changesets);
+            all
+        } else {
+            if !preserved_changesets.is_empty() {
+                restore_prerelease_changesets(&prerelease_dir, &changesets_dir)?;
+            }
+            load_changesets(&changesets_dir, &config.changesets_tags)?
+        }
+    };
+
+    let plan_state = match compute_plan_state(
+        &final_changesets,
+        &workspace,
+        &config,
+        &preserved_targets,
+        true,
+    )? {
+        PlanOutcome::Plan(plan) => plan,
+        PlanOutcome::NoApplicablePackages => {
+            println!("No applicable packages found in changesets.");
+            return Ok(ReleaseOutput {
+                released_packages: vec![],
+                dry_run,
+            });
+        }
+        PlanOutcome::NoMatchingCrates => {
+            println!("No matching workspace crates to release.");
+            return Ok(ReleaseOutput {
+                released_packages: vec![],
+                dry_run,
+            });
+        }
+    };
+
+    let PlanState {
+        mut messages_by_pkg,
+        used_paths,
+        releases,
+        released_packages,
+    } = plan_state;
+
+    print_release_plan(&workspace, &releases);
+
+    if dry_run {
+        println!("Dry-run: no files modified, no tags created.");
+        return Ok(ReleaseOutput {
+            released_packages,
+            dry_run: true,
+        });
+    }
+
+    apply_releases(
+        &releases,
+        &workspace,
+        &mut messages_by_pkg,
+        &final_changesets,
+        &config,
+    )?;
+
+    let prerelease_targets = BTreeSet::new();
+    finalize_consumed_changesets(
+        used_paths,
+        &workspace.root,
+        false,
+        &final_changesets,
+        &workspace,
+        &prerelease_targets,
+    )?;
+
+    let _ = regenerate_lockfile(&workspace);
+
+    Ok(ReleaseOutput {
+        released_packages,
+        dry_run: false,
+    })
+}
+
 fn compute_plan_state(
     changesets: &[ChangesetInfo],
     workspace: &Workspace,
     config: &Config,
     preserved_targets: &BTreeSet<String>,
+    stabilize: bool,
 ) -> Result<PlanOutcome> {
     let (mut bump_by_pkg, messages_by_pkg, used_paths) =
         compute_initial_bumps(changesets, workspace, config)?;
@@ -684,7 +809,7 @@ fn compute_plan_state(
     apply_dependency_cascade(&mut bump_by_pkg, &dependents, config, workspace)?;
     apply_linked_dependencies(&mut bump_by_pkg, config, workspace)?;
 
-    let releases = prepare_release_plan(&bump_by_pkg, workspace, preserved_targets)?;
+    let releases = prepare_release_plan(&bump_by_pkg, workspace, preserved_targets, stabilize)?;
     if releases.is_empty() {
         return Ok(PlanOutcome::NoMatchingCrates);
     }
@@ -1357,6 +1482,7 @@ fn prepare_release_plan(
     bump_by_pkg: &BTreeMap<String, Bump>,
     ws: &Workspace,
     preserved_targets: &BTreeSet<String>,
+    stabilize: bool,
 ) -> Result<ReleasePlan> {
     // Map package identifier -> PackageInfo for quick lookup
     let mut by_id: BTreeMap<String, &PackageInfo> = BTreeMap::new();
@@ -1375,7 +1501,10 @@ fn prepare_release_plan(
 
             let newv = match parse_version_string(&old) {
                 Ok(parsed) => {
-                    if should_bump_prerelease_base(&parsed, identifier, preserved_targets) {
+                    if stabilize && !parsed.pre.is_empty() {
+                        stabilize_version_from_parsed(&parsed, *bump)
+                            .unwrap_or_else(|_| old.clone())
+                    } else if should_bump_prerelease_base(&parsed, identifier, preserved_targets) {
                         bump_prerelease_entry(&parsed, *bump).unwrap_or_else(|_| old.clone())
                     } else {
                         bump_version_from_parsed(&parsed, *bump).unwrap_or_else(|_| old.clone())
@@ -1825,6 +1954,26 @@ fn bump_version_from_parsed(parsed: &Version, bump: Bump) -> std::result::Result
         version.pre = base_pre;
         Ok(version.to_string())
     }
+}
+
+fn stabilize_version_from_parsed(
+    parsed: &Version,
+    bump: Bump,
+) -> std::result::Result<String, String> {
+    let mut version = parsed.clone();
+    if version.pre.is_empty() {
+        apply_base_bump(&mut version, bump)?;
+        return Ok(version.to_string());
+    }
+    let implied = implied_prerelease_bump(&version)?;
+    if bump > implied {
+        // The changeset requests a bump larger than what the prerelease base already encodes,
+        // so we need to apply the additional bump before stripping the suffix.
+        apply_base_bump(&mut version, bump)?;
+    }
+    version.pre = Prerelease::EMPTY;
+    version.build = BuildMetadata::EMPTY;
+    Ok(version.to_string())
 }
 
 /// Bump a semver version string, including pre-release handling
@@ -2328,5 +2477,35 @@ mod tests {
         // The dependency graph should be empty since examples-package is ignored
         // and main-package depends on it
         assert!(dependents.is_empty());
+    }
+
+    #[test]
+    fn test_stabilize_version_from_parsed() {
+        fn stabilize(v: &str, bump: Bump) -> String {
+            let parsed = parse_version_string(v).unwrap();
+            stabilize_version_from_parsed(&parsed, bump).unwrap()
+        }
+
+        // Patch-implied prerelease: bump ≤ implied strips suffix, bump > implied applies bump first
+        assert_eq!(stabilize("0.2.7-alpha.6", Bump::Patch), "0.2.7");
+        assert_eq!(stabilize("0.2.7-alpha.6", Bump::Minor), "0.3.0");
+        assert_eq!(stabilize("0.2.7-alpha.6", Bump::Major), "1.0.0");
+
+        // Minor-implied prerelease
+        assert_eq!(stabilize("0.3.0-alpha", Bump::Patch), "0.3.0");
+        assert_eq!(stabilize("0.3.0-alpha", Bump::Minor), "0.3.0");
+        assert_eq!(stabilize("0.3.0-alpha", Bump::Major), "1.0.0");
+        assert_eq!(stabilize("0.3.0-alpha.1", Bump::Patch), "0.3.0");
+        assert_eq!(stabilize("0.3.0-alpha.1", Bump::Minor), "0.3.0");
+
+        // Major-implied prerelease: any bump strips the suffix
+        assert_eq!(stabilize("1.0.0-alpha", Bump::Patch), "1.0.0");
+        assert_eq!(stabilize("1.0.0-alpha", Bump::Minor), "1.0.0");
+        assert_eq!(stabilize("1.0.0-alpha", Bump::Major), "1.0.0");
+
+        // Stable input: behaves like a normal bump
+        assert_eq!(stabilize("0.2.7", Bump::Patch), "0.2.8");
+        assert_eq!(stabilize("0.2.7", Bump::Minor), "0.3.0");
+        assert_eq!(stabilize("0.2.7", Bump::Major), "1.0.0");
     }
 }

--- a/crates/sampo-core/src/release_tests.rs
+++ b/crates/sampo-core/src/release_tests.rs
@@ -1902,8 +1902,8 @@ bar = { version = "1.0.0", path = "crates/bar" }
         workspace.add_crate("foo", "0.2.7-alpha.6");
         workspace.add_changeset(&["foo"], Bump::Patch, "fix: patch fix");
 
-        let output = run_stabilize_release(&workspace.root, true)
-            .expect("dry-run stabilize should succeed");
+        let output =
+            run_stabilize_release(&workspace.root, true).expect("dry-run stabilize should succeed");
         assert!(output.dry_run);
         assert!(!output.released_packages.is_empty());
         assert_eq!(output.released_packages[0].new_version, "0.2.7");

--- a/crates/sampo-core/src/release_tests.rs
+++ b/crates/sampo-core/src/release_tests.rs
@@ -1816,4 +1816,97 @@ bar = { version = "1.0.0", path = "crates/bar" }
             other => panic!("expected Release error, got {other:?}"),
         }
     }
+
+    #[test]
+    fn stabilize_release_patch_on_prerelease_patch_base() {
+        let mut workspace = TestWorkspace::new();
+        let _guard = EnvVarGuard::set("SAMPO_RELEASE_BRANCH", "main");
+        workspace.add_crate("foo", "0.2.7-alpha.6");
+        workspace.add_changeset(&["foo"], Bump::Patch, "fix: patch fix");
+
+        let output = run_stabilize_release(&workspace.root, false)
+            .expect("stabilize release should succeed");
+        assert!(!output.released_packages.is_empty());
+        workspace.assert_crate_version("foo", "0.2.7");
+    }
+
+    #[test]
+    fn stabilize_release_minor_on_prerelease_patch_base() {
+        let mut workspace = TestWorkspace::new();
+        let _guard = EnvVarGuard::set("SAMPO_RELEASE_BRANCH", "main");
+        workspace.add_crate("foo", "0.2.7-alpha.6");
+        workspace.add_changeset(&["foo"], Bump::Minor, "feat: new feature");
+
+        let output = run_stabilize_release(&workspace.root, false)
+            .expect("stabilize release should succeed");
+        assert!(!output.released_packages.is_empty());
+        workspace.assert_crate_version("foo", "0.3.0");
+    }
+
+    #[test]
+    fn stabilize_release_patch_on_prerelease_minor_base() {
+        let mut workspace = TestWorkspace::new();
+        let _guard = EnvVarGuard::set("SAMPO_RELEASE_BRANCH", "main");
+        workspace.add_crate("foo", "0.3.0-alpha");
+        workspace.add_changeset(&["foo"], Bump::Patch, "fix: patch fix");
+
+        let output = run_stabilize_release(&workspace.root, false)
+            .expect("stabilize release should succeed");
+        assert!(!output.released_packages.is_empty());
+        workspace.assert_crate_version("foo", "0.3.0");
+    }
+
+    #[test]
+    fn stabilize_release_minor_on_prerelease_minor_base() {
+        let mut workspace = TestWorkspace::new();
+        let _guard = EnvVarGuard::set("SAMPO_RELEASE_BRANCH", "main");
+        workspace.add_crate("foo", "0.3.0-alpha");
+        workspace.add_changeset(&["foo"], Bump::Minor, "feat: feature");
+
+        let output = run_stabilize_release(&workspace.root, false)
+            .expect("stabilize release should succeed");
+        assert!(!output.released_packages.is_empty());
+        workspace.assert_crate_version("foo", "0.3.0");
+    }
+
+    #[test]
+    fn stabilize_release_from_preserved_changeset() {
+        let mut workspace = TestWorkspace::new();
+        let _guard = EnvVarGuard::set("SAMPO_RELEASE_BRANCH", "main");
+        workspace.add_crate("foo", "0.2.7-alpha.7");
+        workspace.add_preserved_changeset(&["foo"], Bump::Patch, "fix: preserved patch fix");
+
+        let output = run_stabilize_release(&workspace.root, false)
+            .expect("stabilize release should succeed");
+        assert!(!output.released_packages.is_empty());
+        workspace.assert_crate_version("foo", "0.2.7");
+    }
+
+    #[test]
+    fn stabilize_release_from_preserved_minor_changeset() {
+        let mut workspace = TestWorkspace::new();
+        let _guard = EnvVarGuard::set("SAMPO_RELEASE_BRANCH", "main");
+        workspace.add_crate("foo", "0.3.0-alpha.1");
+        workspace.add_preserved_changeset(&["foo"], Bump::Minor, "feat: preserved feature");
+
+        let output = run_stabilize_release(&workspace.root, false)
+            .expect("stabilize release should succeed");
+        assert!(!output.released_packages.is_empty());
+        workspace.assert_crate_version("foo", "0.3.0");
+    }
+
+    #[test]
+    fn stabilize_release_dry_run_patch_on_prerelease() {
+        let mut workspace = TestWorkspace::new();
+        let _guard = EnvVarGuard::set("SAMPO_RELEASE_BRANCH", "main");
+        workspace.add_crate("foo", "0.2.7-alpha.6");
+        workspace.add_changeset(&["foo"], Bump::Patch, "fix: patch fix");
+
+        let output = run_stabilize_release(&workspace.root, true)
+            .expect("dry-run stabilize should succeed");
+        assert!(output.dry_run);
+        assert!(!output.released_packages.is_empty());
+        assert_eq!(output.released_packages[0].new_version, "0.2.7");
+        workspace.assert_crate_version("foo", "0.2.7-alpha.6");
+    }
 }

--- a/crates/sampo-github-action/src/main.rs
+++ b/crates/sampo-github-action/src/main.rs
@@ -403,10 +403,13 @@ fn execute_operations(
                         branch
                     );
                     let github_client = create_github_client()?;
-                    released = prepare_stabilize_pr(workspace, config, repo_config, branch, &github_client)?;
-                    if released {
-                        return Ok((released, published));
-                    }
+                    released = prepare_stabilize_pr(
+                        workspace,
+                        config,
+                        repo_config,
+                        branch,
+                        &github_client,
+                    )?;
                 }
                 println!(
                     "No pending changesets found on branch '{}'. Checking for merged releases to publish.",

--- a/crates/sampo-github-action/src/main.rs
+++ b/crates/sampo-github-action/src/main.rs
@@ -394,6 +394,20 @@ fn execute_operations(
                 };
                 released = release_prepared || stabilize_prepared;
             } else {
+                // Prerelease packages with preserved changesets need a stabilize PR even
+                // when there are no pending changesets in the regular changesets directory.
+                let prerelease_packages = collect_prerelease_packages(workspace)?;
+                if !prerelease_packages.is_empty() {
+                    println!(
+                        "No pending changesets but prerelease packages exist on branch '{}'; checking for stabilize PR.",
+                        branch
+                    );
+                    let github_client = create_github_client()?;
+                    released = prepare_stabilize_pr(workspace, config, repo_config, branch, &github_client)?;
+                    if released {
+                        return Ok((released, published));
+                    }
+                }
                 println!(
                     "No pending changesets found on branch '{}'. Checking for merged releases to publish.",
                     branch
@@ -606,26 +620,9 @@ fn prepare_stabilize_pr(
         Some(workspace),
     )?;
 
-    let exit_changes = sampo::exit_prerelease(workspace, &prerelease_packages)?;
-    if exit_changes.is_empty() {
-        println!("No packages required exiting pre-release. Skipping stabilize PR.",);
-        git::git(
-            &["reset", "--hard", &format!("origin/{}", base_branch)],
-            Some(workspace),
-        )?;
-        git::git(&["checkout", branch], Some(workspace))?;
-        return Ok(false);
-    }
-    println!(
-        "Exited pre-release mode for {} package(s).",
-        exit_changes.len()
-    );
-
-    let plan = sampo::capture_release_plan(workspace)?;
+    let plan = sampo::capture_stabilize_plan(workspace)?;
     if !plan.has_changes {
-        println!(
-            "No stable release changes detected after exiting pre-release. Skipping stabilize PR.",
-        );
+        println!("No stable release changes detected. Skipping stabilize PR.");
         git::git(
             &["reset", "--hard", &format!("origin/{}", base_branch)],
             Some(workspace),
@@ -648,7 +645,7 @@ fn prepare_stabilize_pr(
         body
     };
 
-    sampo::run_release(workspace, false, config.cargo_token.as_deref())?;
+    sampo::run_stabilize_release(workspace, false, config.cargo_token.as_deref())?;
 
     if !git::has_changes(workspace)? {
         println!("No file changes after stabilize release. Skipping commit/PR.");

--- a/crates/sampo-github-action/src/sampo.rs
+++ b/crates/sampo-github-action/src/sampo.rs
@@ -6,9 +6,8 @@ use sampo_core::types::{
 use sampo_core::{
     Config, PublishExtraArgs, PublishOutput, detect_all_dependency_explanations,
     detect_github_repo_slug_with_config, discover_workspace, enrich_changeset_message,
-    get_commit_hash_for_path, load_changesets,
-    run_publish as core_publish, run_release as core_release,
-    run_stabilize_release as core_stabilize_release,
+    get_commit_hash_for_path, load_changesets, run_publish as core_publish,
+    run_release as core_release, run_stabilize_release as core_stabilize_release,
 };
 use std::collections::BTreeMap;
 use std::path::Path;
@@ -104,7 +103,11 @@ pub fn capture_stabilize_plan(workspace: &Path) -> Result<ReleasePlan> {
 }
 
 /// Execute stabilize release (prerelease → stable).
-pub fn run_stabilize_release(workspace: &Path, dry_run: bool, cargo_token: Option<&str>) -> Result<()> {
+pub fn run_stabilize_release(
+    workspace: &Path,
+    dry_run: bool,
+    cargo_token: Option<&str>,
+) -> Result<()> {
     if let Some(token) = cargo_token {
         set_cargo_env_var(token);
     }

--- a/crates/sampo-github-action/src/sampo.rs
+++ b/crates/sampo-github-action/src/sampo.rs
@@ -4,10 +4,11 @@ use sampo_core::types::{
     ChangelogCategory, PackageSpecifier, SpecResolution, format_ambiguity_options,
 };
 use sampo_core::{
-    Config, PublishExtraArgs, PublishOutput, VersionChange, detect_all_dependency_explanations,
+    Config, PublishExtraArgs, PublishOutput, detect_all_dependency_explanations,
     detect_github_repo_slug_with_config, discover_workspace, enrich_changeset_message,
-    exit_prerelease as core_exit_prerelease, get_commit_hash_for_path, load_changesets,
+    get_commit_hash_for_path, load_changesets,
     run_publish as core_publish, run_release as core_release,
+    run_stabilize_release as core_stabilize_release,
 };
 use std::collections::BTreeMap;
 use std::path::Path;
@@ -80,12 +81,40 @@ pub fn run_publish(
     })
 }
 
-/// Exit pre-release mode for the provided packages.
-pub fn exit_prerelease(workspace: &Path, packages: &[String]) -> Result<Vec<VersionChange>> {
-    core_exit_prerelease(workspace, packages).map_err(|e| ActionError::SampoCommandFailed {
-        operation: "exit-prerelease".to_string(),
-        message: format!("sampo pre exit failed: {}", e),
+/// Dry-run stabilize release to compute the stable version plan.
+pub fn capture_stabilize_plan(workspace: &Path) -> Result<ReleasePlan> {
+    let release_output =
+        core_stabilize_release(workspace, true).map_err(|e| ActionError::SampoCommandFailed {
+            operation: "stabilize-plan".to_string(),
+            message: format!("Stabilize plan failed: {}", e),
+        })?;
+
+    let has_changes = !release_output.released_packages.is_empty();
+    let mut releases: BTreeMap<String, (String, String, String)> = BTreeMap::new();
+    if has_changes {
+        for pkg in release_output.released_packages {
+            releases.insert(pkg.identifier, (pkg.name, pkg.old_version, pkg.new_version));
+        }
+    }
+
+    Ok(ReleasePlan {
+        has_changes,
+        releases,
     })
+}
+
+/// Execute stabilize release (prerelease → stable).
+pub fn run_stabilize_release(workspace: &Path, dry_run: bool, cargo_token: Option<&str>) -> Result<()> {
+    if let Some(token) = cargo_token {
+        set_cargo_env_var(token);
+    }
+
+    core_stabilize_release(workspace, dry_run).map_err(|e| ActionError::SampoCommandFailed {
+        operation: "stabilize-release".to_string(),
+        message: format!("sampo stabilize release failed: {}", e),
+    })?;
+
+    Ok(())
 }
 
 /// Compute a markdown PR body summarizing the pending release by crate,


### PR DESCRIPTION
## What has changed?

- **`sampo-core`**: Added `run_stabilize_release`, a new public function that transitions prerelease packages to stable. It uses a new private `stabilize_version_from_parsed` helper that strips the prerelease suffix and only applies an additional bump when the changeset requests a larger change than what the prerelease base already encodes (e.g. `0.2.7-alpha.6` + patch → `0.2.7`, not `0.2.8`). Added `stabilize: bool` to `compute_plan_state` and `prepare_release_plan` to route version computation through this helper.
- **`sampo-github-action`**: `prepare_stabilize_pr` no longer calls `exit_prerelease` before computing the release plan. It now uses `capture_stabilize_plan` and `run_stabilize_release`, which compute the correct stable version in one step. `execute_operations` (Auto mode) now checks for prerelease packages when `capture_release_plan` returns no changes, so a stabilize PR is created even after a prerelease PR has been merged and its changesets moved to `.sampo/prerelease/`.

## How is it tested?

- Added `test_stabilize_version_from_parsed` unit test in `release.rs` covering patch/minor/major bumps against patch-, minor-, and major-implied prereleases, plus stable inputs.
- Added 7 integration tests in `release_tests.rs`: current-changeset scenarios (Bug 1) and preserved-changeset scenarios (Bug 2), including a dry-run variant.

## How is it documented?

No documentation changes needed — these are internal fixes with no user-facing API or configuration changes.