### PR TITLE
fix(sampo-core): Fixes dev deps cycle not being allowed in Cargo

### DIFF
--- a/.sampo/changesets/cantankerous-wolfkin-tuulikki.md
+++ b/.sampo/changesets/cantankerous-wolfkin-tuulikki.md
@@ -1,0 +1,5 @@
+---
+cargo/sampo-core: patch
+---
+
+Fixes valid dependencies cycles inside dev deps in Cargo preventing publishes despite being allowed by Cargo

--- a/.sampo/changesets/cantankerous-wolfkin-tuulikki.md
+++ b/.sampo/changesets/cantankerous-wolfkin-tuulikki.md
@@ -2,4 +2,4 @@
 cargo/sampo-core: patch
 ---
 
-Fixes valid dependencies cycles inside dev deps in Cargo preventing publishes despite being allowed by Cargo
+Fixes valid dependency cycles in Cargo dev-dependencies that were preventing publishes despite being allowed by Cargo

--- a/crates/sampo-core/src/adapters/cargo.rs
+++ b/crates/sampo-core/src/adapters/cargo.rs
@@ -897,26 +897,40 @@ fn expand_cargo_member_pattern(
     Ok(())
 }
 
-/// Collect internal dependencies for a crate
+/// Collect internal dependencies for a crate.
+/// Returns (internal_deps, internal_dev_deps). Dev-dependencies are tracked
+/// separately because they don't create publish-order constraints (cargo strips
+/// them during publish), but their versions still potentially need updating during releases.
 fn collect_cargo_internal_deps(
     crate_dir: &Path,
     name_to_path: &BTreeMap<String, PathBuf>,
     manifest: &toml::Value,
-) -> BTreeSet<String> {
+) -> (BTreeSet<String>, BTreeSet<String>) {
     let mut internal = BTreeSet::new();
+    let mut internal_dev = BTreeSet::new();
     for key in ["dependencies", "dev-dependencies", "build-dependencies"] {
         if let Some(tbl) = manifest.get(key).and_then(|v| v.as_table()) {
             for (dep_name, dep_val) in tbl {
                 if is_cargo_internal_dep(crate_dir, name_to_path, dep_name, dep_val) {
-                    internal.insert(PackageInfo::dependency_identifier(
-                        PackageKind::Cargo,
-                        dep_name,
-                    ));
+                    let id = PackageInfo::dependency_identifier(PackageKind::Cargo, dep_name);
+                    if key == "dev-dependencies" {
+                        // Only track dev-deps that have a version field —
+                        // path-only dev-deps have no version to update.
+                        let has_version = dep_val
+                            .as_table()
+                            .map(|t| t.contains_key("version"))
+                            .unwrap_or(false);
+                        if has_version {
+                            internal_dev.insert(id);
+                        }
+                    } else {
+                        internal.insert(id);
+                    }
                 }
             }
         }
     }
-    internal
+    (internal, internal_dev)
 }
 
 /// Check if a dependency is internal to the workspace
@@ -1037,13 +1051,15 @@ fn discover_cargo(root: &Path) -> std::result::Result<Vec<PackageInfo>, Workspac
     let mut out: Vec<PackageInfo> = Vec::new();
     for (name, version, path, manifest) in crates {
         let identifier = PackageInfo::dependency_identifier(PackageKind::Cargo, &name);
-        let internal_deps = collect_cargo_internal_deps(&path, &name_to_path, &manifest);
+        let (internal_deps, internal_dev_deps) =
+            collect_cargo_internal_deps(&path, &name_to_path, &manifest);
         out.push(PackageInfo {
             name,
             identifier,
             version,
             path,
             internal_deps,
+            internal_dev_deps,
             kind: PackageKind::Cargo,
         });
     }

--- a/crates/sampo-core/src/adapters/cargo/cargo_tests.rs
+++ b/crates/sampo-core/src/adapters/cargo/cargo_tests.rs
@@ -148,6 +148,57 @@ fn cargo_discoverer_detects_internal_deps() {
 }
 
 #[test]
+fn cargo_discoverer_separates_dev_deps() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+
+    fs::write(
+        root.join("Cargo.toml"),
+        "[workspace]\nmembers = [\"crates/*\"]\n",
+    )
+    .unwrap();
+
+    let crates_dir = root.join("crates");
+    fs::create_dir_all(crates_dir.join("pkg-a")).unwrap();
+    fs::create_dir_all(crates_dir.join("pkg-b")).unwrap();
+    fs::create_dir_all(crates_dir.join("pkg-c")).unwrap();
+
+    // pkg-a: regular dep on pkg-b, dev-dep with version on pkg-c
+    fs::write(
+        crates_dir.join("pkg-a/Cargo.toml"),
+        "[package]\nname=\"pkg-a\"\nversion=\"0.1.0\"\n\
+         [dependencies]\npkg-b={ version=\"0.1.0\", path=\"../pkg-b\" }\n\
+         [dev-dependencies]\npkg-c={ version=\"0.1.0\", path=\"../pkg-c\" }\n",
+    )
+    .unwrap();
+    // pkg-b: dev-dep on pkg-a, path-only (no version)
+    fs::write(
+        crates_dir.join("pkg-b/Cargo.toml"),
+        "[package]\nname=\"pkg-b\"\nversion=\"0.1.0\"\n\
+         [dev-dependencies]\npkg-a={ path=\"../pkg-a\" }\n",
+    )
+    .unwrap();
+    fs::write(
+        crates_dir.join("pkg-c/Cargo.toml"),
+        "[package]\nname=\"pkg-c\"\nversion=\"0.1.0\"\n",
+    )
+    .unwrap();
+
+    let packages = discover_cargo(root).unwrap();
+    let pkg_a = packages.iter().find(|p| p.name == "pkg-a").unwrap();
+    let pkg_b = packages.iter().find(|p| p.name == "pkg-b").unwrap();
+
+    // pkg-a: regular dep on pkg-b, dev-dep (with version) on pkg-c
+    assert!(pkg_a.internal_deps.contains("cargo/pkg-b"));
+    assert!(!pkg_a.internal_deps.contains("cargo/pkg-c"));
+    assert!(pkg_a.internal_dev_deps.contains("cargo/pkg-c"));
+
+    // pkg-b: path-only dev-dep on pkg-a should NOT appear in internal_dev_deps
+    assert!(pkg_b.internal_deps.is_empty());
+    assert!(pkg_b.internal_dev_deps.is_empty());
+}
+
+#[test]
 fn skips_workspace_dependencies_when_updating() {
     let input = "[package]\nname=\"demo\"\nversion=\"0.1.0\"\n\n[dependencies]\nfoo = { workspace = true, optional = true }\n";
     let mut updates = BTreeMap::new();

--- a/crates/sampo-core/src/adapters/hex/mix.rs
+++ b/crates/sampo-core/src/adapters/hex/mix.rs
@@ -105,6 +105,7 @@ pub(super) fn discover(root: &Path) -> std::result::Result<Vec<PackageInfo>, Wor
             version,
             path: dir,
             internal_deps: internal,
+            internal_dev_deps: BTreeSet::new(),
             kind: PackageKind::Hex,
         });
     }

--- a/crates/sampo-core/src/adapters/npm.rs
+++ b/crates/sampo-core/src/adapters/npm.rs
@@ -872,6 +872,7 @@ fn discover_npm(root: &Path) -> std::result::Result<Vec<PackageInfo>, WorkspaceE
             path,
             identifier,
             internal_deps,
+            internal_dev_deps: BTreeSet::new(),
             kind: PackageKind::Npm,
         });
     }

--- a/crates/sampo-core/src/adapters/packagist.rs
+++ b/crates/sampo-core/src/adapters/packagist.rs
@@ -571,6 +571,7 @@ fn discover_packagist(root: &Path) -> std::result::Result<Vec<PackageInfo>, Work
         version,
         path: root.to_path_buf(),
         internal_deps: std::collections::BTreeSet::new(),
+        internal_dev_deps: std::collections::BTreeSet::new(),
         kind: PackageKind::Packagist,
     }];
 

--- a/crates/sampo-core/src/adapters/pypi/pip.rs
+++ b/crates/sampo-core/src/adapters/pypi/pip.rs
@@ -147,6 +147,7 @@ pub(super) fn discover(root: &Path) -> std::result::Result<Vec<PackageInfo>, Wor
             version,
             path: dir,
             internal_deps: internal,
+            internal_dev_deps: BTreeSet::new(),
             kind: PackageKind::PyPI,
         });
     }

--- a/crates/sampo-core/src/filters.rs
+++ b/crates/sampo-core/src/filters.rs
@@ -129,6 +129,7 @@ mod tests {
                     version: "0.1.0".into(),
                     path: PathBuf::from("/repo/tools/internal-tool"),
                     internal_deps: Default::default(),
+                    internal_dev_deps: BTreeSet::new(),
                     kind: PackageKind::Cargo,
                 },
                 PackageInfo {
@@ -137,6 +138,7 @@ mod tests {
                     version: "0.1.0".into(),
                     path: PathBuf::from("/repo/examples/lib"),
                     internal_deps: Default::default(),
+                    internal_dev_deps: BTreeSet::new(),
                     kind: PackageKind::Cargo,
                 },
                 PackageInfo {
@@ -145,6 +147,7 @@ mod tests {
                     version: "0.1.0".into(),
                     path: PathBuf::from("/repo/crates/normal"),
                     internal_deps: Default::default(),
+                    internal_dev_deps: BTreeSet::new(),
                     kind: PackageKind::Cargo,
                 },
             ],

--- a/crates/sampo-core/src/publish.rs
+++ b/crates/sampo-core/src/publish.rs
@@ -860,6 +860,7 @@ fn main() {
             version: "0.1.0".into(),
             path: PathBuf::from("/tmp/a"),
             internal_deps: BTreeSet::new(),
+            internal_dev_deps: BTreeSet::new(),
             kind: PackageKind::Cargo,
         };
         let mut deps_b = BTreeSet::new();
@@ -870,6 +871,7 @@ fn main() {
             version: "0.1.0".into(),
             path: PathBuf::from("/tmp/b"),
             internal_deps: deps_b,
+            internal_dev_deps: BTreeSet::new(),
             kind: PackageKind::Cargo,
         };
         let mut deps_c = BTreeSet::new();
@@ -880,6 +882,7 @@ fn main() {
             version: "0.1.0".into(),
             path: PathBuf::from("/tmp/c"),
             internal_deps: deps_c,
+            internal_dev_deps: BTreeSet::new(),
             kind: PackageKind::Cargo,
         };
 
@@ -908,6 +911,7 @@ fn main() {
             version: "0.1.0".into(),
             path: PathBuf::from("/tmp/a"),
             internal_deps: deps_a,
+            internal_dev_deps: BTreeSet::new(),
             kind: PackageKind::Cargo,
         };
 
@@ -919,6 +923,7 @@ fn main() {
             version: "0.1.0".into(),
             path: PathBuf::from("/tmp/b"),
             internal_deps: deps_b,
+            internal_dev_deps: BTreeSet::new(),
             kind: PackageKind::Cargo,
         };
 
@@ -933,6 +938,43 @@ fn main() {
         let result = topo_order(&map, &include);
         assert!(result.is_err());
         assert!(format!("{}", result.unwrap_err()).contains("dependency cycle"));
+    }
+
+    #[test]
+    fn dev_dep_cycle_does_not_block_publish_ordering() {
+        // A depends on B (regular dep), B dev-depends on A.
+        // This is valid in Cargo (dev-deps are stripped on publish)
+        // and should not be detected as a cycle.
+        let a = PackageInfo {
+            name: "a".into(),
+            identifier: "cargo/a".into(),
+            version: "0.1.0".into(),
+            path: PathBuf::from("/tmp/a"),
+            internal_deps: BTreeSet::new(),
+            internal_dev_deps: BTreeSet::new(),
+            kind: PackageKind::Cargo,
+        };
+        let b = PackageInfo {
+            name: "b".into(),
+            identifier: "cargo/b".into(),
+            version: "0.1.0".into(),
+            path: PathBuf::from("/tmp/b"),
+            internal_deps: BTreeSet::from(["cargo/a".into()]),
+            // dev-dep back to A — should NOT create a cycle
+            internal_dev_deps: BTreeSet::from(["cargo/a".into()]),
+            kind: PackageKind::Cargo,
+        };
+
+        let mut map: BTreeMap<String, &PackageInfo> = BTreeMap::new();
+        map.insert("cargo/a".into(), &a);
+        map.insert("cargo/b".into(), &b);
+
+        let mut include = BTreeSet::new();
+        include.insert("cargo/a".into());
+        include.insert("cargo/b".into());
+
+        let order = topo_order(&map, &include).unwrap();
+        assert_eq!(order, vec!["cargo/a", "cargo/b"]);
     }
 
     #[test]
@@ -1302,6 +1344,7 @@ edition = "2021"
                     version: "1.0.0".to_string(),
                     path: main_pkg,
                     internal_deps: BTreeSet::new(),
+                    internal_dev_deps: BTreeSet::new(),
                     kind: PackageKind::Cargo,
                 },
                 PackageInfo {
@@ -1313,6 +1356,7 @@ edition = "2021"
                     version: "1.0.0".to_string(),
                     path: examples_pkg,
                     internal_deps: BTreeSet::new(),
+                    internal_dev_deps: BTreeSet::new(),
                     kind: PackageKind::Cargo,
                 },
             ],

--- a/crates/sampo-core/src/publish.rs
+++ b/crates/sampo-core/src/publish.rs
@@ -950,7 +950,7 @@ fn main() {
             identifier: "cargo/a".into(),
             version: "0.1.0".into(),
             path: PathBuf::from("/tmp/a"),
-            internal_deps: BTreeSet::new(),
+            internal_deps: BTreeSet::from(["cargo/b".into()]),
             internal_dev_deps: BTreeSet::new(),
             kind: PackageKind::Cargo,
         };
@@ -959,8 +959,8 @@ fn main() {
             identifier: "cargo/b".into(),
             version: "0.1.0".into(),
             path: PathBuf::from("/tmp/b"),
-            internal_deps: BTreeSet::from(["cargo/a".into()]),
-            // dev-dep back to A — should NOT create a cycle
+            internal_deps: BTreeSet::new(),
+            // dev-dep back to A — would be a cycle if counted for publish ordering
             internal_dev_deps: BTreeSet::from(["cargo/a".into()]),
             kind: PackageKind::Cargo,
         };
@@ -974,7 +974,7 @@ fn main() {
         include.insert("cargo/b".into());
 
         let order = topo_order(&map, &include).unwrap();
-        assert_eq!(order, vec!["cargo/a", "cargo/b"]);
+        assert_eq!(order, vec!["cargo/b", "cargo/a"]);
     }
 
     #[test]

--- a/crates/sampo-core/src/release.rs
+++ b/crates/sampo-core/src/release.rs
@@ -292,7 +292,7 @@ pub fn detect_all_dependency_explanations(
         if let Some(crate_info) = by_id.get(crate_id) {
             // Find which internal dependencies were updated
             let mut updated_deps = Vec::new();
-            for dep_name in &crate_info.internal_deps {
+            for dep_name in crate_info.internal_deps.iter().chain(&crate_info.internal_dev_deps) {
                 if let Some(new_version) = new_version_by_name.get(dep_name as &str) {
                     // This internal dependency was updated
                     let display_dep = by_id
@@ -355,7 +355,7 @@ pub fn detect_fixed_dependency_policy_packages(
             continue;
         }
 
-        for dep_name in &crate_info.internal_deps {
+        for dep_name in crate_info.internal_deps.iter().chain(&crate_info.internal_dev_deps) {
             dependents
                 .entry(dep_name.clone())
                 .or_default()
@@ -1187,7 +1187,7 @@ fn build_dependency_graph(ws: &Workspace, cfg: &Config) -> BTreeMap<String, BTre
             continue;
         }
 
-        for dep in &c.internal_deps {
+        for dep in c.internal_deps.iter().chain(&c.internal_dev_deps) {
             // Also skip dependencies that point to ignored packages
             if ignored_packages.contains(dep) {
                 continue;
@@ -2232,6 +2232,7 @@ mod tests {
                     version: "1.0.0".to_string(),
                     path: root.join("main-package"),
                     internal_deps: BTreeSet::new(),
+                    internal_dev_deps: BTreeSet::new(),
                     kind: PackageKind::Cargo,
                 },
                 PackageInfo {
@@ -2240,6 +2241,7 @@ mod tests {
                     version: "1.0.0".to_string(),
                     path: root.join("examples/package"),
                     internal_deps: BTreeSet::new(),
+                    internal_dev_deps: BTreeSet::new(),
                     kind: PackageKind::Cargo,
                 },
                 PackageInfo {
@@ -2248,6 +2250,7 @@ mod tests {
                     version: "1.0.0".to_string(),
                     path: root.join("benchmarks/utils"),
                     internal_deps: BTreeSet::new(),
+                    internal_dev_deps: BTreeSet::new(),
                     kind: PackageKind::Cargo,
                 },
             ],
@@ -2299,6 +2302,7 @@ mod tests {
                     version: "1.0.0".to_string(),
                     path: root.join("main-package"),
                     internal_deps: ["cargo/examples-package".to_string()].into_iter().collect(),
+                    internal_dev_deps: BTreeSet::new(),
                     kind: PackageKind::Cargo,
                 },
                 PackageInfo {
@@ -2307,6 +2311,7 @@ mod tests {
                     version: "1.0.0".to_string(),
                     path: root.join("examples/package"),
                     internal_deps: BTreeSet::new(),
+                    internal_dev_deps: BTreeSet::new(),
                     kind: PackageKind::Cargo,
                 },
             ],

--- a/crates/sampo-core/src/release_tests.rs
+++ b/crates/sampo-core/src/release_tests.rs
@@ -1577,6 +1577,7 @@ tempfile = "3.0"
                     version: "1.0.0".to_string(),
                     path: PathBuf::from("/test/pkg-a"),
                     internal_deps: BTreeSet::from(["cargo/pkg-b".to_string()]),
+                    internal_dev_deps: BTreeSet::new(),
                     kind: PackageKind::Cargo,
                 },
                 PackageInfo {
@@ -1585,6 +1586,7 @@ tempfile = "3.0"
                     version: "1.0.0".to_string(),
                     path: PathBuf::from("/test/pkg-b"),
                     internal_deps: BTreeSet::new(),
+                    internal_dev_deps: BTreeSet::new(),
                     kind: PackageKind::Cargo,
                 },
                 PackageInfo {
@@ -1593,6 +1595,7 @@ tempfile = "3.0"
                     version: "1.0.0".to_string(),
                     path: PathBuf::from("/test/pkg-c"),
                     internal_deps: BTreeSet::new(),
+                    internal_dev_deps: BTreeSet::new(),
                     kind: PackageKind::Cargo,
                 },
             ],
@@ -1679,6 +1682,7 @@ tempfile = "3.0"
                 version: "1.0.0".to_string(),
                 path: PathBuf::from("/test/pkg-a"),
                 internal_deps: BTreeSet::new(),
+                internal_dev_deps: BTreeSet::new(),
                 kind: PackageKind::Cargo,
             }],
         };

--- a/crates/sampo-core/src/types.rs
+++ b/crates/sampo-core/src/types.rs
@@ -174,6 +174,9 @@ pub struct PackageInfo {
     pub version: String,
     pub path: PathBuf,
     pub internal_deps: BTreeSet<String>,
+    /// Dev-only internal dependencies (not needed for publish ordering, but
+    /// their versions should still be updated during releases).
+    pub internal_dev_deps: BTreeSet<String>,
     pub kind: PackageKind,
 }
 
@@ -552,6 +555,7 @@ mod tests {
             version: "0.1.0".to_string(),
             path: PathBuf::from(format!("crates/{name}")),
             internal_deps: BTreeSet::new(),
+            internal_dev_deps: BTreeSet::new(),
             kind: PackageKind::Cargo,
         }
     }


### PR DESCRIPTION
## What has changed?

Cargo allows cycle inside dev deps, because they get completely stripped when publishing. It is a quite common thing inside a Rust monorepo because your library might be split in multiple parts, and you need to setup the tests of the current crate with code from another crate of your monorepo.

This PR fixes sampo incorrectly reporting this as preventing a publish

## How is it tested?

Added a test and updated tests that needed it

## How is it documented?

N/A
