### PR TITLE
fix(sampo-core): support bun.lock

### DIFF
--- a/.sampo/changesets/valorous-stormcaller-ilmatar.md
+++ b/.sampo/changesets/valorous-stormcaller-ilmatar.md
@@ -1,0 +1,5 @@
+---
+cargo/sampo-core: patch
+---
+
+Support new plaintext bun.lock format

--- a/crates/sampo-core/src/adapters/npm.rs
+++ b/crates/sampo-core/src/adapters/npm.rs
@@ -453,9 +453,7 @@ fn detect_package_manager(dir: &Path, info: &NpmManifestInfo) -> PackageManager 
         if ancestor.join("pnpm-lock.yaml").exists() {
             return PackageManager::Pnpm;
         }
-        if ancestor.join("bun.lockb").exists()
-            || ancestor.join("bun.lock").exists()
-        {
+        if ancestor.join("bun.lockb").exists() || ancestor.join("bun.lock").exists() {
             return PackageManager::Bun;
         }
         if ancestor.join("yarn.lock").exists() {
@@ -572,9 +570,7 @@ fn detect_workspace_package_manager(workspace_root: &Path) -> Result<PackageMana
     if workspace_root.join("pnpm-lock.yaml").exists() {
         return Ok(PackageManager::Pnpm);
     }
-    if workspace_root.join("bun.lockb").exists()
-        || workspace_root.join("bun.lock").exists()
-    {
+    if workspace_root.join("bun.lockb").exists() || workspace_root.join("bun.lock").exists() {
         return Ok(PackageManager::Bun);
     }
     if workspace_root.join("yarn.lock").exists() {

--- a/crates/sampo-core/src/adapters/npm.rs
+++ b/crates/sampo-core/src/adapters/npm.rs
@@ -453,7 +453,9 @@ fn detect_package_manager(dir: &Path, info: &NpmManifestInfo) -> PackageManager 
         if ancestor.join("pnpm-lock.yaml").exists() {
             return PackageManager::Pnpm;
         }
-        if ancestor.join("bun.lockb").exists() {
+        if ancestor.join("bun.lockb").exists()
+            || ancestor.join("bun.lock").exists()
+        {
             return PackageManager::Bun;
         }
         if ancestor.join("yarn.lock").exists() {
@@ -526,7 +528,11 @@ fn regenerate_npm_lockfile(workspace_root: &Path) -> Result<()> {
         PackageManager::Bun => (
             "bun",
             vec!["install", "--frozen-lockfile=false"],
-            "bun.lockb",
+            if workspace_root.join("bun.lockb").exists() {
+                "bun.lockb"
+            } else {
+                "bun.lock"
+            },
         ),
     };
 
@@ -566,7 +572,9 @@ fn detect_workspace_package_manager(workspace_root: &Path) -> Result<PackageMana
     if workspace_root.join("pnpm-lock.yaml").exists() {
         return Ok(PackageManager::Pnpm);
     }
-    if workspace_root.join("bun.lockb").exists() {
+    if workspace_root.join("bun.lockb").exists()
+        || workspace_root.join("bun.lock").exists()
+    {
         return Ok(PackageManager::Bun);
     }
     if workspace_root.join("yarn.lock").exists() {

--- a/crates/sampo-core/src/adapters/npm/npm_tests.rs
+++ b/crates/sampo-core/src/adapters/npm/npm_tests.rs
@@ -259,7 +259,7 @@ fn detect_workspace_package_manager_pnpm() {
 }
 
 #[test]
-fn detect_workspace_package_manager_bun() {
+fn detect_workspace_package_manager_bun_old() {
     let temp = tempdir().unwrap();
     let root = temp.path();
     fs::write(
@@ -268,6 +268,21 @@ fn detect_workspace_package_manager_bun() {
     )
     .unwrap();
     fs::write(root.join("bun.lockb"), "").unwrap();
+
+    let result = super::detect_workspace_package_manager(root).unwrap();
+    assert_eq!(result, super::PackageManager::Bun);
+}
+
+#[test]
+fn detect_workspace_package_manager_bun() {
+    let temp = tempdir().unwrap();
+    let root = temp.path();
+    fs::write(
+        root.join("package.json"),
+        r#"{"name":"app","version":"0.1.0"}"#,
+    )
+    .unwrap();
+    fs::write(root.join("bun.lock"), "").unwrap();
 
     let result = super::detect_workspace_package_manager(root).unwrap();
     assert_eq!(result, super::PackageManager::Bun);

--- a/crates/sampo-core/src/release.rs
+++ b/crates/sampo-core/src/release.rs
@@ -292,7 +292,11 @@ pub fn detect_all_dependency_explanations(
         if let Some(crate_info) = by_id.get(crate_id) {
             // Find which internal dependencies were updated
             let mut updated_deps = Vec::new();
-            for dep_name in crate_info.internal_deps.iter().chain(&crate_info.internal_dev_deps) {
+            for dep_name in crate_info
+                .internal_deps
+                .iter()
+                .chain(&crate_info.internal_dev_deps)
+            {
                 if let Some(new_version) = new_version_by_name.get(dep_name as &str) {
                     // This internal dependency was updated
                     let display_dep = by_id
@@ -355,7 +359,11 @@ pub fn detect_fixed_dependency_policy_packages(
             continue;
         }
 
-        for dep_name in crate_info.internal_deps.iter().chain(&crate_info.internal_dev_deps) {
+        for dep_name in crate_info
+            .internal_deps
+            .iter()
+            .chain(&crate_info.internal_dev_deps)
+        {
             dependents
                 .entry(dep_name.clone())
                 .or_default()

--- a/crates/sampo-core/src/release.rs
+++ b/crates/sampo-core/src/release.rs
@@ -1205,6 +1205,7 @@ pub(crate) fn regenerate_lockfile(workspace: &Workspace) -> Result<()> {
                     || workspace.root.join("pnpm-lock.yaml").exists()
                     || workspace.root.join("yarn.lock").exists()
                     || workspace.root.join("bun.lockb").exists()
+                    || workspace.root.join("bun.lock").exists()
                     || workspace.root.join("npm-shrinkwrap.json").exists()
             }
             PackageKind::Hex => workspace.root.join("mix.lock").exists(),


### PR DESCRIPTION
Closes: #232

## What has changed?

Support `bun.lock` when `bun.lockb` is missing (`bun.lock` is the new lockfile format for bun)

## How is it tested?

Added a new test to confirm behavior.

## How is it documented?

Bun is claimed as something supported, but latest versions aren't currently supported.