### PR TITLE
feat(cli): optional feature for self-update

### DIFF
--- a/.sampo/changesets/misty-fjord-kalevala.md
+++ b/.sampo/changesets/misty-fjord-kalevala.md
@@ -1,0 +1,5 @@
+---
+cargo/sampo: patch
+---
+
+Changed `sampo update` to be an optional Cargo feature (`self-update`, enabled by default). Disable it with `--no-default-features` to exclude self-update dependency and reduce binary size.

--- a/crates/sampo/Cargo.toml
+++ b/crates/sampo/Cargo.toml
@@ -26,7 +26,7 @@ sampo-core = { version = "0.14.0", path = "../sampo-core" }
 clap = { version = "4.6", features = ["derive"] }
 dialoguer = { version = "0.12", default-features = true }
 dirs = "6.0.0"
-self_update = { version = "0.44", default-features = false, features = [
+self_update = { version = "0.44", optional = true, default-features = false, features = [
     "archive-tar",
     "compression-flate2",
     "reqwest",
@@ -35,6 +35,10 @@ self_update = { version = "0.44", default-features = false, features = [
 
 [dev-dependencies]
 tempfile = "3"
+
+[features]
+default = ["self-update"]
+self-update = ["dep:self_update"]
 
 [package.metadata.binstall]
 pkg-url = "{ repo }/releases/download/cargo-{ name }-v{ version }/{ name }-{ version }-{ target }{ archive-suffix }"

--- a/crates/sampo/README.md
+++ b/crates/sampo/README.md
@@ -245,15 +245,15 @@ Sampo detects packages within the same repository that depend on each other and 
 
 All commands should be run from the root of the repository:
 
-| Command         | Description                                                               |
-| --------------- | ------------------------------------------------------------------------- |
-| `sampo help`    | Show commands or the help of the given subcommand(s)                      |
-| `sampo init`    | Initialize Sampo in the current repository                                |
-| `sampo add`     | Create a new changeset                                                    |
-| `sampo pre`     | Manage pre-release versions (enter or exit pre-release mode)              |
-| `sampo release` | Consume changesets, and prepare release(s) (bump versions and changelogs) |
-| `sampo publish` | Publish packages to registries and tag current versions                   |
-| `sampo update`  | Update Sampo CLI to the latest version                                    |
+| Command         | Description                                                                                    |
+| --------------- | ---------------------------------------------------------------------------------------------- |
+| `sampo help`    | Show commands or the help of the given subcommand(s)                                           |
+| `sampo init`    | Initialize Sampo in the current repository                                                     |
+| `sampo add`     | Create a new changeset                                                                         |
+| `sampo pre`     | Manage pre-release versions (enter or exit pre-release mode)                                   |
+| `sampo release` | Consume changesets, and prepare release(s) (bump versions and changelogs)                      |
+| `sampo publish` | Publish packages to registries and tag current versions                                        |
+| `sampo update`  | Update Sampo CLI to the latest version. Optional: can be disabled with `--no-default-features` |
 
 For detailed command options, use `sampo help <command>` or `sampo <command> --help`.
 

--- a/crates/sampo/src/cli.rs
+++ b/crates/sampo/src/cli.rs
@@ -28,6 +28,7 @@ pub enum Commands {
     Pre(PreArgs),
 
     /// Update Sampo CLI to the latest version
+    #[cfg(feature = "self-update")]
     Update(UpdateArgs),
 }
 
@@ -122,6 +123,7 @@ pub struct PreExitArgs {
     pub package: Vec<String>,
 }
 
+#[cfg(feature = "self-update")]
 #[derive(Debug, Args, Default)]
 pub struct UpdateArgs {
     /// Skip confirmation prompt
@@ -329,51 +331,6 @@ mod tests {
     }
 
     #[test]
-    fn parses_update() {
-        let cli = Cli::try_parse_from(["sampo", "update"]).unwrap();
-        match cli.command {
-            Commands::Update(args) => assert!(!args.yes),
-            _ => panic!("wrong variant"),
-        }
-    }
-
-    #[test]
-    fn parses_update_with_yes() {
-        let cli = Cli::try_parse_from(["sampo", "update", "--yes"]).unwrap();
-        match cli.command {
-            Commands::Update(args) => {
-                assert!(args.yes);
-                assert!(!args.pre);
-            }
-            _ => panic!("wrong variant"),
-        }
-    }
-
-    #[test]
-    fn parses_update_with_pre() {
-        let cli = Cli::try_parse_from(["sampo", "update", "--pre"]).unwrap();
-        match cli.command {
-            Commands::Update(args) => {
-                assert!(!args.yes);
-                assert!(args.pre);
-            }
-            _ => panic!("wrong variant"),
-        }
-    }
-
-    #[test]
-    fn parses_update_with_yes_and_pre() {
-        let cli = Cli::try_parse_from(["sampo", "update", "--yes", "--pre"]).unwrap();
-        match cli.command {
-            Commands::Update(args) => {
-                assert!(args.yes);
-                assert!(args.pre);
-            }
-            _ => panic!("wrong variant"),
-        }
-    }
-
-    #[test]
     fn parses_publish_cargo_args_with_hyphen_values() {
         let cli = Cli::try_parse_from([
             "sampo",
@@ -440,6 +397,56 @@ mod tests {
                 );
             }
             _ => panic!("wrong variant"),
+        }
+    }
+
+    #[cfg(feature = "self-update")]
+    mod update {
+        use super::*;
+
+        #[test]
+        fn parses_update() {
+            let cli = Cli::try_parse_from(["sampo", "update"]).unwrap();
+            match cli.command {
+                Commands::Update(args) => assert!(!args.yes),
+                _ => panic!("wrong variant"),
+            }
+        }
+
+        #[test]
+        fn parses_update_with_yes() {
+            let cli = Cli::try_parse_from(["sampo", "update", "--yes"]).unwrap();
+            match cli.command {
+                Commands::Update(args) => {
+                    assert!(args.yes);
+                    assert!(!args.pre);
+                }
+                _ => panic!("wrong variant"),
+            }
+        }
+
+        #[test]
+        fn parses_update_with_pre() {
+            let cli = Cli::try_parse_from(["sampo", "update", "--pre"]).unwrap();
+            match cli.command {
+                Commands::Update(args) => {
+                    assert!(!args.yes);
+                    assert!(args.pre);
+                }
+                _ => panic!("wrong variant"),
+            }
+        }
+
+        #[test]
+        fn parses_update_with_yes_and_pre() {
+            let cli = Cli::try_parse_from(["sampo", "update", "--yes", "--pre"]).unwrap();
+            match cli.command {
+                Commands::Update(args) => {
+                    assert!(args.yes);
+                    assert!(args.pre);
+                }
+                _ => panic!("wrong variant"),
+            }
         }
     }
 }

--- a/crates/sampo/src/main.rs
+++ b/crates/sampo/src/main.rs
@@ -6,6 +6,7 @@ mod prerelease;
 mod publish;
 mod release;
 mod ui;
+#[cfg(feature = "self-update")]
 mod update;
 mod version_check;
 
@@ -98,6 +99,7 @@ fn main() -> ExitCode {
                 return exit::ERROR;
             }
         },
+        #[cfg(feature = "self-update")]
         Commands::Update(args) => match update::run(&args) {
             Ok(true) => {}
             Ok(false) => return exit::no_changes(),
@@ -117,7 +119,11 @@ fn check_and_notify_update() {
         version_check::check_for_updates()
     {
         ui::log_hint(&format!(
-            "A new version of Sampo is available: {current} → {latest}. Run `sampo update` to update."
+            "A new version of Sampo is available: {current} → {latest}."
         ));
+
+        if cfg!(feature = "self-update") {
+            ui::log_hint("Run `sampo update` to update.");
+        }
     }
 }


### PR DESCRIPTION
Resolves #275

## What has changed?
- `crates/sampo/Cargo.toml`: Added `self-update` feature and mark it as default.
- `crates/sampo/src/cli.rs`:  Added checks for `self-update` feature, move tests related to update into `tests::update` module.
- `crates/sampo/src/main.rs`: Added checks for `self-update` feature. Split new version availability and `sampo update` command hints.

## How is it tested?
- `cargo test` / `cargo run` with/without `--no-default-features`

## How is it documented?
- `crates/sampo/README.md`: Documented `sampo update` command as optional in the Commands table.