### PR TITLE
feat(core): authenticate npm version checks for private registries

### DIFF
--- a/.sampo/changesets/hidden-harbor-ilmarinen.md
+++ b/.sampo/changesets/hidden-harbor-ilmarinen.md
@@ -1,0 +1,7 @@
+---
+cargo/sampo-core: patch
+cargo/sampo: patch
+cargo/sampo-github-action: patch
+---
+
+In JavaScript/TypeScript (npm) projects, added support for private registries. `sampo publish` now authenticates its check for already-published versions with `NPM_TOKEN` or `NODE_AUTH_TOKEN`.

--- a/.sampo/changesets/hidden-harbor-ilmarinen.md
+++ b/.sampo/changesets/hidden-harbor-ilmarinen.md
@@ -4,4 +4,4 @@ cargo/sampo: patch
 cargo/sampo-github-action: patch
 ---
 
-In JavaScript/TypeScript (npm) projects, added support for private registries. `sampo publish` now authenticates its check for already-published versions with `NPM_TOKEN` or `NODE_AUTH_TOKEN`.
+In JavaScript/TypeScript (npm) projects, added support for private registries. `sampo publish` now authenticates its check for already-published versions with `NPM_TOKEN` or `NODE_AUTH_TOKEN`, falling back to your `.npmrc` when neither is set.

--- a/crates/sampo-core/CHANGELOG.md
+++ b/crates/sampo-core/CHANGELOG.md
@@ -13,7 +13,7 @@
 
 ### Patch changes
 
-- [042f263](https://github.com/bruits/sampo/commit/042f26354212981f462597d8355c63b90aad433c) In JavaScript (npm) projects, added support for Bun's new plaintext `bun.lock` lockfile format. — Thanks @davidroeca for your first contribution 🎉!
+- [042f263](https://github.com/bruits/sampo/commit/042f26354212981f462597d8355c63b90aad433c) In JavaScript/TypeScript (npm) projects, added support for Bun's new plaintext `bun.lock` lockfile format. — Thanks @davidroeca for your first contribution 🎉!
 - [914328a](https://github.com/bruits/sampo/commit/914328a066311c92015409b1a18ac23295aef7be) In Cargo projects, fixed unnecessarily adding versions to path-only dev dependencies, which caused publish failures when the dev dependency was also bumped in the same release. — Thanks @Princesseuh!
 
 ## 0.13.2 — 2026-04-10
@@ -238,4 +238,3 @@
 ### Minor changes
 
 - [78515cc](https://github.com/bruits/sampo/commit/78515ccfbf53dcd952dc7f7e7716c0f0a5fc82b6) Initial release of `sampo-core`, a foundational crate providing core logic, common types, and internal utilities shared across all Sampo crates. — Thanks Goulven Clec'h!
-

--- a/crates/sampo-core/src/adapters/npm.rs
+++ b/crates/sampo-core/src/adapters/npm.rs
@@ -81,9 +81,10 @@ impl NpmAdapter {
                     package_name,
                     version,
                     info.publish_config.registry.as_deref(),
+                    path.parent(),
                 )
             }
-            None => version_exists_on_registry(package_name, version, None),
+            None => version_exists_on_registry(package_name, version, None, None),
         }
     }
 
@@ -757,6 +758,7 @@ fn version_exists_on_registry(
     package_name: &str,
     version: &str,
     registry_override: Option<&str>,
+    manifest_dir: Option<&Path>,
 ) -> Result<bool> {
     enforce_registry_rate_limit();
 
@@ -801,16 +803,14 @@ fn version_exists_on_registry(
     } else if status == StatusCode::NOT_FOUND {
         Ok(false)
     } else if status == StatusCode::UNAUTHORIZED || status == StatusCode::FORBIDDEN {
-        let hint = if token.is_some() {
-            "the provided NPM_TOKEN/NODE_AUTH_TOKEN was rejected"
-        } else {
-            "set NPM_TOKEN or NODE_AUTH_TOKEN to authenticate reads against a private registry"
-        };
+        if should_fall_back_to_npmrc(token.is_some()) {
+            return version_exists_via_npm(package_name, version, registry_override, manifest_dir);
+        }
         let body = response.text().unwrap_or_default();
         let snippet: String = body.trim().chars().take(400).collect();
         Err(SampoError::Publish(format!(
-            "Registry {} returned {} ({}): {}",
-            url, status, hint, snippet
+            "Registry {} returned {} (the provided NPM_TOKEN/NODE_AUTH_TOKEN was rejected): {}",
+            url, status, snippet
         )))
     } else if status == StatusCode::TOO_MANY_REQUESTS {
         let retry_after = response
@@ -857,6 +857,71 @@ fn version_check_request(
     match token {
         Some(token) => request.bearer_auth(token),
         None => request,
+    }
+}
+
+/// Fall back to `.npmrc` only when no env token was set; a rejected token
+/// surfaces the error instead of silently retrying through another mechanism.
+fn should_fall_back_to_npmrc(token_present: bool) -> bool {
+    !token_present
+}
+
+/// Delegate the existence check to `npm`, reusing its `.npmrc` resolution instead
+/// of reimplementing it. Runs in the package directory so a project `.npmrc` is
+/// picked up; `npm` is used regardless of workspace manager since pnpm, bun, and
+/// Yarn Classic also read `.npmrc`.
+fn version_exists_via_npm(
+    package_name: &str,
+    version: &str,
+    registry_override: Option<&str>,
+    manifest_dir: Option<&Path>,
+) -> Result<bool> {
+    let spec = format!("{package_name}@{version}");
+    let mut cmd = command("npm");
+    cmd.args(npm_view_args(&spec, registry_override));
+    if let Some(dir) = manifest_dir {
+        cmd.current_dir(dir);
+    }
+    let output = cmd.output().map_err(|err| {
+        if err.kind() == std::io::ErrorKind::NotFound {
+            SampoError::Publish(format!(
+                "npm not found in PATH; it is needed to read .npmrc when checking '{spec}' against a private registry. Set NPM_TOKEN/NODE_AUTH_TOKEN or install npm."
+            ))
+        } else {
+            SampoError::Io(err)
+        }
+    })?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    interpret_npm_view(
+        output.status.success(),
+        stdout.as_ref(),
+        stderr.as_ref(),
+        &spec,
+    )
+}
+
+fn npm_view_args(spec: &str, registry_override: Option<&str>) -> Vec<String> {
+    let mut args = vec!["view".to_string(), spec.to_string(), "version".to_string()];
+    if let Some(registry) = registry_override.map(str::trim).filter(|s| !s.is_empty()) {
+        args.push("--registry".to_string());
+        args.push(registry.to_string());
+    }
+    args
+}
+
+/// Map `npm view` output to existence: a matching version prints it (exit 0), a
+/// missing one exits with `E404`, and any other failure is surfaced as an error.
+fn interpret_npm_view(success: bool, stdout: &str, stderr: &str, spec: &str) -> Result<bool> {
+    if success {
+        Ok(!stdout.trim().is_empty())
+    } else if stderr.contains("E404") {
+        Ok(false)
+    } else {
+        let snippet: String = stderr.trim().chars().take(400).collect();
+        Err(SampoError::Publish(format!(
+            "npm view failed for '{spec}': {snippet}"
+        )))
     }
 }
 

--- a/crates/sampo-core/src/adapters/npm.rs
+++ b/crates/sampo-core/src/adapters/npm.rs
@@ -773,8 +773,10 @@ fn version_exists_on_registry(
         .build()
         .map_err(|err| SampoError::Publish(format!("failed to build HTTP client: {}", err)))?;
 
-    let response = client
-        .get(url.clone())
+    // Private registries may require auth even for reads; this direct HTTP call
+    // can't rely on the package manager's .npmrc.
+    let token = npm_auth_token();
+    let response = version_check_request(&client, url.clone(), token.as_deref())
         .send()
         .map_err(|err| SampoError::Publish(format!("HTTP request to {} failed: {}", url, err)))?;
 
@@ -798,6 +800,18 @@ fn version_exists_on_registry(
         Ok(versions.contains_key(version))
     } else if status == StatusCode::NOT_FOUND {
         Ok(false)
+    } else if status == StatusCode::UNAUTHORIZED || status == StatusCode::FORBIDDEN {
+        let hint = if token.is_some() {
+            "the provided NPM_TOKEN/NODE_AUTH_TOKEN was rejected"
+        } else {
+            "set NPM_TOKEN or NODE_AUTH_TOKEN to authenticate reads against a private registry"
+        };
+        let body = response.text().unwrap_or_default();
+        let snippet: String = body.trim().chars().take(400).collect();
+        Err(SampoError::Publish(format!(
+            "Registry {} returned {} ({}): {}",
+            url, status, hint, snippet
+        )))
     } else if status == StatusCode::TOO_MANY_REQUESTS {
         let retry_after = response
             .headers()
@@ -817,6 +831,32 @@ fn version_exists_on_registry(
             "Registry {} returned {}: {}",
             url, status, snippet
         )))
+    }
+}
+
+/// `NPM_TOKEN` takes precedence over `NODE_AUTH_TOKEN`; `None` when neither is set.
+fn npm_auth_token() -> Option<String> {
+    resolve_npm_auth_token(|key| std::env::var(key).ok())
+}
+
+fn resolve_npm_auth_token(lookup: impl Fn(&str) -> Option<String>) -> Option<String> {
+    ["NPM_TOKEN", "NODE_AUTH_TOKEN"]
+        .into_iter()
+        .find_map(|key| {
+            let trimmed = lookup(key)?.trim().to_string();
+            (!trimmed.is_empty()).then_some(trimmed)
+        })
+}
+
+fn version_check_request(
+    client: &reqwest::blocking::Client,
+    url: reqwest::Url,
+    token: Option<&str>,
+) -> reqwest::blocking::RequestBuilder {
+    let request = client.get(url);
+    match token {
+        Some(token) => request.bearer_auth(token),
+        None => request,
     }
 }
 

--- a/crates/sampo-core/src/adapters/npm/npm_tests.rs
+++ b/crates/sampo-core/src/adapters/npm/npm_tests.rs
@@ -866,6 +866,65 @@ fn version_check_request_omits_auth_without_token() {
 }
 
 #[test]
+fn falls_back_to_npmrc_only_without_env_token() {
+    assert!(super::should_fall_back_to_npmrc(false));
+    assert!(!super::should_fall_back_to_npmrc(true));
+}
+
+#[test]
+fn npm_view_args_includes_registry_override() {
+    let args = super::npm_view_args("pkg@1.2.3", Some("https://registry.example.com/"));
+    assert_eq!(
+        args,
+        [
+            "view",
+            "pkg@1.2.3",
+            "version",
+            "--registry",
+            "https://registry.example.com/"
+        ]
+    );
+}
+
+#[test]
+fn npm_view_args_omits_registry_when_absent_or_blank() {
+    assert_eq!(
+        super::npm_view_args("pkg@1.2.3", None),
+        ["view", "pkg@1.2.3", "version"]
+    );
+    assert_eq!(
+        super::npm_view_args("pkg@1.2.3", Some("   ")),
+        ["view", "pkg@1.2.3", "version"]
+    );
+}
+
+#[test]
+fn interpret_npm_view_reports_existing_version() {
+    assert!(super::interpret_npm_view(true, "1.2.3\n", "", "pkg@1.2.3").unwrap());
+}
+
+#[test]
+fn interpret_npm_view_treats_empty_success_as_absent() {
+    assert!(!super::interpret_npm_view(true, "  \n", "", "pkg@9.9.9").unwrap());
+}
+
+#[test]
+fn interpret_npm_view_treats_e404_as_absent() {
+    assert!(
+        !super::interpret_npm_view(false, "", "npm error code E404\nnpm error 404", "pkg@9.9.9")
+            .unwrap()
+    );
+}
+
+#[test]
+fn interpret_npm_view_surfaces_other_failures() {
+    let err =
+        super::interpret_npm_view(false, "", "npm error code E401\nUnauthorized", "pkg@1.0.0")
+            .unwrap_err();
+    assert!(err.to_string().contains("npm view failed"));
+}
+
+#[test]
 fn detect_workspace_package_manager_fails_when_no_indicators() {
     let temp = tempdir().unwrap();
     let root = temp.path();

--- a/crates/sampo-core/src/adapters/npm/npm_tests.rs
+++ b/crates/sampo-core/src/adapters/npm/npm_tests.rs
@@ -799,6 +799,73 @@ fn detect_workspace_package_manager_prioritizes_lockfile_over_field() {
 }
 
 #[test]
+fn resolve_npm_auth_token_prefers_npm_token() {
+    let token = super::resolve_npm_auth_token(|key| match key {
+        "NPM_TOKEN" => Some("primary".to_string()),
+        "NODE_AUTH_TOKEN" => Some("secondary".to_string()),
+        _ => None,
+    });
+    assert_eq!(token.as_deref(), Some("primary"));
+}
+
+#[test]
+fn resolve_npm_auth_token_falls_back_to_node_auth_token() {
+    let token = super::resolve_npm_auth_token(|key| match key {
+        "NODE_AUTH_TOKEN" => Some("secondary".to_string()),
+        _ => None,
+    });
+    assert_eq!(token.as_deref(), Some("secondary"));
+}
+
+#[test]
+fn resolve_npm_auth_token_ignores_blank_values() {
+    // A blank NPM_TOKEN must not mask a real NODE_AUTH_TOKEN (common when an
+    // unset CI secret expands to an empty string).
+    let token = super::resolve_npm_auth_token(|key| match key {
+        "NPM_TOKEN" => Some("   ".to_string()),
+        "NODE_AUTH_TOKEN" => Some("real".to_string()),
+        _ => None,
+    });
+    assert_eq!(token.as_deref(), Some("real"));
+}
+
+#[test]
+fn resolve_npm_auth_token_none_when_unset() {
+    assert!(super::resolve_npm_auth_token(|_| None).is_none());
+}
+
+#[test]
+fn version_check_request_attaches_bearer_token() {
+    let client = reqwest::blocking::Client::new();
+    let url = reqwest::Url::parse("https://registry.example.com/pkg").unwrap();
+    let request = super::version_check_request(&client, url, Some("secret-token"))
+        .build()
+        .unwrap();
+    assert_eq!(
+        request
+            .headers()
+            .get(reqwest::header::AUTHORIZATION)
+            .unwrap(),
+        "Bearer secret-token"
+    );
+}
+
+#[test]
+fn version_check_request_omits_auth_without_token() {
+    let client = reqwest::blocking::Client::new();
+    let url = reqwest::Url::parse("https://registry.npmjs.org/pkg").unwrap();
+    let request = super::version_check_request(&client, url, None)
+        .build()
+        .unwrap();
+    assert!(
+        request
+            .headers()
+            .get(reqwest::header::AUTHORIZATION)
+            .is_none()
+    );
+}
+
+#[test]
 fn detect_workspace_package_manager_fails_when_no_indicators() {
     let temp = tempdir().unwrap();
     let root = temp.path();

--- a/crates/sampo-github-action/CHANGELOG.md
+++ b/crates/sampo-github-action/CHANGELOG.md
@@ -17,7 +17,7 @@
 
 ### Patch changes
 
-- [042f263](https://github.com/bruits/sampo/commit/042f26354212981f462597d8355c63b90aad433c) In JavaScript (npm) projects, added support for Bun's new plaintext `bun.lock` lockfile format. — Thanks @davidroeca for your first contribution 🎉!
+- [042f263](https://github.com/bruits/sampo/commit/042f26354212981f462597d8355c63b90aad433c) In JavaScript/TypeScript (npm) projects, added support for Bun's new plaintext `bun.lock` lockfile format. — Thanks @davidroeca for your first contribution 🎉!
 - [914328a](https://github.com/bruits/sampo/commit/914328a066311c92015409b1a18ac23295aef7be) In Cargo projects, fixed unnecessarily adding versions to path-only dev dependencies, which caused publish failures when the dev dependency was also bumped in the same release. — Thanks @Princesseuh!
 - Updated dependencies: sampo-core@0.13.3
 
@@ -350,4 +350,3 @@
 
 - [`d0d7244`](https://github.com/bruits/sampo/commit/d0d7244a43d76a0d7b377cf5f328a1fe244282b4) Changelog messages are now enriched with commit hash links and author thank-you notes, especially for first-time contributors. Added `[changelog]` configuration section with `show_commit_hash` and `show_acknowledgments` options (both default to true). — Thanks @goulvenclech!
 - [`c7f252e`](https://github.com/bruits/sampo/commit/c7f252ef8c2671c3d35a3a69ab878591f024bf4a) Initial release of Sampo's GitHub Action, to help you automate release workflows in CI/CD pipelines. Supports multiple operation modes: `prepare-pr` (creates/updates Release PRs), `post-merge-publish` (publishes and tags after merge), and traditional `release`/`publish` commands. — Thanks @goulvenclech!
-

--- a/crates/sampo/CHANGELOG.md
+++ b/crates/sampo/CHANGELOG.md
@@ -26,7 +26,7 @@
 
 ### Patch changes
 
-- [042f263](https://github.com/bruits/sampo/commit/042f26354212981f462597d8355c63b90aad433c) In JavaScript (npm) projects, added support for Bun's new plaintext `bun.lock` lockfile format. — Thanks @davidroeca for your first contribution 🎉!
+- [042f263](https://github.com/bruits/sampo/commit/042f26354212981f462597d8355c63b90aad433c) In JavaScript/TypeScript (npm) projects, added support for Bun's new plaintext `bun.lock` lockfile format. — Thanks @davidroeca for your first contribution 🎉!
 - [914328a](https://github.com/bruits/sampo/commit/914328a066311c92015409b1a18ac23295aef7be) In Cargo projects, fixed unnecessarily adding versions to path-only dev dependencies, which caused publish failures when the dev dependency was also bumped in the same release. — Thanks @Princesseuh!
 - Updated dependencies: sampo-core@0.13.3
 
@@ -326,4 +326,3 @@
 ### Minor changes
 
 - Initial release of Sampo CLI, a tool to automate changelogs, versioning, and publishing. This first version includes proof of concepts for the main commands (`help`, `init`, `add`, `release`, `publish`), and has been published using Sampo itself!
-

--- a/crates/sampo/README.md
+++ b/crates/sampo/README.md
@@ -4,7 +4,7 @@ Automate changelogs, versioning, and publishing—even for monorepos across mult
 
 **In a nutshell,** Sampo is a CLI, a GitHub App, and a GitHub Action, that automatically detects packages in your repository, and uses changesets (markdown files describing changes explicitly) to bump versions (in SemVer format), generate changelogs (human-readable files listing changes), and publish packages (to their respective registries). It's designed to be easy to opt-in and opt-out, with minimal configuration required, sensible defaults, and no assumptions/constraints on your workflow (except using SemVer).
 
-If you’ve ever struggled with keeping user-facing changelogs updated, coordinating version bumps across dependent packages, or automating your publishing process... Sampo might be the tool you were looking for!
+If you've ever struggled with keeping user-facing changelogs updated, coordinating version bumps across dependent packages, or automating your publishing process... Sampo might be the tool you were looking for!
 
 ## Getting Started
 
@@ -229,7 +229,7 @@ You can ignore certain packages, so they do not appear in the CLI commands, chan
 > [!NOTE]
 > Canonical identifiers follow the `<ecosystem>/<name>` format (e.g., `cargo/my-crate` for a Rust package, `npm/web-app` for a JavaScript package, `packagist/vendor/package` for a PHP package). Sampo continues to accept plain names, but you'll be prompted to disambiguate if a name appears in multiple ecosystems.
 
-Sampo detects packages within the same repository that depend on each other and automatically manages their versions. By default, dependent packages are automatically patched when a workspace dependency is updated. For example: if `a@0.1.0` depends on `b@0.1.0` and `b` is updated to `0.2.0`, then `a` will be automatically bumped to `0.1.1` (patch). If `a` needs a major or minor change due to `b`'s update, it should be explicitly specified in a changeset. Some options allow customizing this behavior:
+Sampo detects packages within the same monorepo (even one mixing ecosystems) that depend on each other, and automatically manages their versions. By default, dependent packages are automatically patched when a workspace dependency is updated. The cascade is transitive, so indirect dependents are bumped too. For example: if `a@0.1.0` depends on `b@0.1.0` and `b` is updated to `0.2.0`, then `a` will be automatically bumped to `0.1.1` (patch). If `a` needs a major or minor change due to `b`'s update, it should be explicitly specified in a changeset. Some options allow customizing this behavior:
 
 `fixed`: An array of dependency groups (default: `[]`) where packages in each group are bumped together with the same version level. Each group is an array of packages and can mix ecosystems. When any package in a group is updated, all other packages in the same group receive the same version bump, regardless of actual dependencies. For example: if `fixed = [["cargo/a", "cargo/b"], ["cargo/c", "cargo/d"]]` and `cargo/a` is updated to `2.0.0` (major), then `cargo/b` will also be bumped to `2.0.0`, but `cargo/c` and `cargo/d` remain unchanged.
 


### PR DESCRIPTION
## What has changed?

Closes #278. In JavaScript/TypeScript (npm) projects, added support for private registries. `sampo publish` now authenticates its check for already-published versions with `NPM_TOKEN` or `NODE_AUTH_TOKEN`, falling back to `.npmrc` when neither is set.

## How is it tested?

Unit tests in `npm_tests.rs` cover token precedence (`NPM_TOKEN` over `NODE_AUTH_TOKEN`), blank-value handling, the request wiring (bearer header present with a token, absent without), the fallback gating (defer to `.npmrc` only when no env token is set), and the `npm view` argv plus output interpretation (existing version, `E404` → absent, other failures surfaced).

## How is it documented?

Relies on already documented npm's `NPM_TOKEN`/`NODE_AUTH_TOKEN` and `.npmrc` conventions.