### PR TITLE
feat(core): alternative and private Cargo registries

### DIFF
--- a/.sampo/changesets/hidden-harbor-ilmarinen.md
+++ b/.sampo/changesets/hidden-harbor-ilmarinen.md
@@ -1,7 +1,7 @@
 ---
-cargo/sampo-core: patch
-cargo/sampo: patch
-cargo/sampo-github-action: patch
+cargo/sampo-core: minor
+cargo/sampo: minor
+cargo/sampo-github-action: minor
 ---
 
 In JavaScript/TypeScript (npm) projects, added support for private registries. `sampo publish` now authenticates its check for already-published versions with `NPM_TOKEN` or `NODE_AUTH_TOKEN`, falling back to your `.npmrc` when neither is set.

--- a/.sampo/changesets/northern-harbor-louhi.md
+++ b/.sampo/changesets/northern-harbor-louhi.md
@@ -1,7 +1,7 @@
 ---
-cargo/sampo-core: patch
-cargo/sampo: patch
-cargo/sampo-github-action: patch
+cargo/sampo-core: minor
+cargo/sampo: minor
+cargo/sampo-github-action: minor
 ---
 
 In Cargo (Rust) projects, added support for alternative and private registries, and fixed crates that publish solely to an alternative registry (`publish = ["my-registry"]`) being wrongly marked as non-publishable. `sampo publish` now checks whether a version already exists on the target registry using your Cargo registry configuration and credentials.

--- a/.sampo/changesets/northern-harbor-louhi.md
+++ b/.sampo/changesets/northern-harbor-louhi.md
@@ -1,0 +1,7 @@
+---
+cargo/sampo-core: patch
+cargo/sampo: patch
+cargo/sampo-github-action: patch
+---
+
+In Cargo (Rust) projects, added support for alternative and private registries, and fixed crates that publish solely to an alternative registry (`publish = ["my-registry"]`) being wrongly marked as non-publishable. `sampo publish` now checks whether a version already exists on the target registry using your Cargo registry configuration and credentials.

--- a/crates/sampo-core/src/adapters.rs
+++ b/crates/sampo-core/src/adapters.rs
@@ -85,7 +85,7 @@ impl PackageAdapter {
         manifest_path: Option<&Path>,
     ) -> Result<bool> {
         match self {
-            Self::Cargo => cargo::CargoAdapter.version_exists(package_name, version),
+            Self::Cargo => cargo::CargoAdapter.version_exists(package_name, version, manifest_path),
             Self::Npm => npm::NpmAdapter.version_exists(package_name, version, manifest_path),
             Self::Hex => hex::HexAdapter.version_exists(package_name, version, manifest_path),
             Self::PyPI => pypi::PyPIAdapter.version_exists(package_name, version, manifest_path),

--- a/crates/sampo-core/src/adapters/cargo.rs
+++ b/crates/sampo-core/src/adapters/cargo.rs
@@ -33,11 +33,16 @@ impl CargoAdapter {
     }
 
     pub(super) fn is_publishable(&self, manifest_path: &Path) -> Result<bool> {
-        is_publishable_to_crates_io(manifest_path)
+        read_manifest_publishable(manifest_path)
     }
 
-    pub(super) fn version_exists(&self, package_name: &str, version: &str) -> Result<bool> {
-        version_exists_on_crates_io(package_name, version)
+    pub(super) fn version_exists(
+        &self,
+        package_name: &str,
+        version: &str,
+        manifest_path: Option<&Path>,
+    ) -> Result<bool> {
+        cargo_version_exists(package_name, version, manifest_path)
     }
 
     pub(super) fn publish(
@@ -276,30 +281,120 @@ fn run_cargo_dry_run(
         })
 }
 
-/// Check Cargo.toml `publish` field per Cargo rules (false, array of registries, or default true).
-fn is_publishable_to_crates_io(manifest_path: &Path) -> Result<bool> {
+fn read_manifest_publishable(manifest_path: &Path) -> Result<bool> {
     let text = fs::read_to_string(manifest_path)
         .map_err(|e| SampoError::Io(crate::errors::io_error_with_path(e, manifest_path)))?;
     let value: toml::Value = toml::from_str(&text).map_err(|e| {
         SampoError::InvalidData(format!("invalid TOML in {}: {e}", manifest_path.display()))
     })?;
-    Ok(manifest_allows_crates_io(&value))
+    Ok(manifest_allows_publish(&value))
 }
 
-/// Whether a parsed Cargo manifest may be published to crates.io, per its
-/// `[package].publish` field.
-fn manifest_allows_crates_io(value: &toml::Value) -> bool {
+/// Per `[package].publish`, Cargo forbids publishing only when the field is `false`
+/// or an empty list; a single alternative registry stays publishable.
+fn manifest_allows_publish(value: &toml::Value) -> bool {
     let Some(pkg) = value.get("package").and_then(|v| v.as_table()) else {
         return false;
     };
     match pkg.get("publish") {
         Some(toml::Value::Boolean(false)) => false,
-        Some(toml::Value::Array(arr)) => arr
-            .iter()
-            .filter_map(|v| v.as_str())
-            .any(|s| s == "crates-io"),
+        Some(toml::Value::Array(arr)) => !arr.is_empty(),
         _ => true,
     }
+}
+
+/// The single alternative registry a crate publishes to, if any.
+///
+/// Mirrors Cargo's auto-selection: a lone non-crates.io entry is the target; an absent
+/// field, multiple registries, or an explicit `crates-io` all default to crates.io
+/// (`None`).
+fn manifest_publish_target(value: &toml::Value) -> Option<String> {
+    let arr = value
+        .get("package")
+        .and_then(|v| v.as_table())?
+        .get("publish")?
+        .as_array()?;
+    let [only] = arr.as_slice() else {
+        return None;
+    };
+    let name = only.as_str()?;
+    (name != "crates-io").then(|| name.to_string())
+}
+
+/// Alternative registries go through `cargo info` to reuse Cargo's config resolution
+/// and stored credentials; crates.io uses its HTTP API directly.
+fn cargo_version_exists(
+    crate_name: &str,
+    version: &str,
+    manifest_path: Option<&Path>,
+) -> Result<bool> {
+    if let Some(path) = manifest_path
+        && let Some(registry) = publish_target_registry(path)
+    {
+        return version_exists_via_cargo_info(crate_name, version, &registry, path);
+    }
+    version_exists_on_crates_io(crate_name, version)
+}
+
+fn publish_target_registry(manifest_path: &Path) -> Option<String> {
+    let text = fs::read_to_string(manifest_path).ok()?;
+    let value: toml::Value = toml::from_str(&text).ok()?;
+    manifest_publish_target(&value)
+}
+
+/// Runs from the manifest directory so Cargo's config discovery walks up to the
+/// `.cargo/config.toml` that defines the registry.
+fn version_exists_via_cargo_info(
+    crate_name: &str,
+    version: &str,
+    registry: &str,
+    manifest_path: &Path,
+) -> Result<bool> {
+    let spec = format!("{}@{}", crate_name, version);
+    let mut cmd = Command::new("cargo");
+    cmd.args(cargo_info_args(&spec, registry));
+    if let Some(dir) = manifest_path.parent() {
+        cmd.current_dir(dir);
+    }
+
+    let output = cmd.output().map_err(|err| {
+        if err.kind() == std::io::ErrorKind::NotFound {
+            SampoError::Publish(
+                "cargo not found in PATH; it is needed to check existing versions on alternative registries"
+                    .to_string(),
+            )
+        } else {
+            SampoError::Io(err)
+        }
+    })?;
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    interpret_cargo_info(output.status.success(), stderr.as_ref(), &spec, registry)
+}
+
+fn cargo_info_args(spec: &str, registry: &str) -> Vec<String> {
+    vec![
+        "info".to_string(),
+        spec.to_string(),
+        "--registry".to_string(),
+        registry.to_string(),
+    ]
+}
+
+/// Only a "could not find ... in registry" failure means absent; any other failure
+/// (auth, network) is surfaced as an error rather than mistaken for a missing version.
+fn interpret_cargo_info(success: bool, stderr: &str, spec: &str, registry: &str) -> Result<bool> {
+    if success {
+        return Ok(true);
+    }
+    if stderr.contains("could not find") && stderr.contains("in registry") {
+        return Ok(false);
+    }
+    let snippet: String = stderr.trim().chars().take(400).collect();
+    Err(SampoError::Publish(format!(
+        "cargo info failed for '{}' on registry '{}': {}",
+        spec, registry, snippet
+    )))
 }
 
 /// Query crates.io API to check if a specific version already exists.
@@ -1260,7 +1355,7 @@ fn discover_cargo(root: &Path) -> std::result::Result<Vec<PackageInfo>, Workspac
             .to_string();
         let version = resolve_package_version(pkg, &workspace_version, &manifest_path)?;
         // A non-publishable, versionless crate is not a release target.
-        if version.is_empty() && !manifest_allows_crates_io(&value) {
+        if version.is_empty() && !manifest_allows_publish(&value) {
             continue;
         }
         name_to_path.insert(name.clone(), member_dir.clone());

--- a/crates/sampo-core/src/adapters/cargo/cargo_tests.rs
+++ b/crates/sampo-core/src/adapters/cargo/cargo_tests.rs
@@ -1009,3 +1009,124 @@ mod range_constraint_preservation {
         );
     }
 }
+
+mod private_registries {
+    use super::*;
+
+    fn manifest(toml_src: &str) -> toml::Value {
+        toml::from_str(toml_src).unwrap()
+    }
+
+    #[test]
+    fn allows_publish_for_absent_field_and_true() {
+        assert!(manifest_allows_publish(&manifest(
+            "[package]\nname=\"a\"\nversion=\"0.1.0\"\n"
+        )));
+        assert!(manifest_allows_publish(&manifest(
+            "[package]\nname=\"a\"\nversion=\"0.1.0\"\npublish = true\n"
+        )));
+    }
+
+    #[test]
+    fn allows_publish_for_any_non_empty_registry_list() {
+        for publish in ["[\"crates-io\"]", "[\"my-registry\"]", "[\"a\", \"b\"]"] {
+            let src = format!("[package]\nname=\"a\"\nversion=\"0.1.0\"\npublish = {publish}\n");
+            assert!(
+                manifest_allows_publish(&manifest(&src)),
+                "publish = {publish}"
+            );
+        }
+    }
+
+    #[test]
+    fn forbids_publish_for_false_or_empty_list() {
+        assert!(!manifest_allows_publish(&manifest(
+            "[package]\nname=\"a\"\nversion=\"0.1.0\"\npublish = false\n"
+        )));
+        assert!(!manifest_allows_publish(&manifest(
+            "[package]\nname=\"a\"\nversion=\"0.1.0\"\npublish = []\n"
+        )));
+    }
+
+    #[test]
+    fn forbids_publish_without_package_section() {
+        assert!(!manifest_allows_publish(&manifest(
+            "[dependencies]\nserde = \"1\"\n"
+        )));
+    }
+
+    #[test]
+    fn publish_target_is_single_alternative_registry() {
+        assert_eq!(
+            manifest_publish_target(&manifest(
+                "[package]\nname=\"a\"\nversion=\"0.1.0\"\npublish = [\"my-registry\"]\n"
+            )),
+            Some("my-registry".to_string())
+        );
+    }
+
+    #[test]
+    fn publish_target_none_when_resolving_to_crates_io() {
+        for src in [
+            "[package]\nname=\"a\"\nversion=\"0.1.0\"\npublish = [\"crates-io\"]\n",
+            "[package]\nname=\"a\"\nversion=\"0.1.0\"\npublish = [\"my-registry\", \"crates-io\"]\n",
+            "[package]\nname=\"a\"\nversion=\"0.1.0\"\n",
+        ] {
+            assert_eq!(
+                manifest_publish_target(&manifest(src)),
+                None,
+                "src = {src:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn cargo_info_args_include_spec_and_registry() {
+        assert_eq!(
+            cargo_info_args("my-crate@1.2.3", "my-registry"),
+            ["info", "my-crate@1.2.3", "--registry", "my-registry"]
+        );
+    }
+
+    #[test]
+    fn interpret_cargo_info_reports_existing_version() {
+        assert!(interpret_cargo_info(true, "", "my-crate@1.2.3", "my-registry").unwrap());
+    }
+
+    #[test]
+    fn interpret_cargo_info_treats_missing_version_as_absent() {
+        let stderr = "error: could not find `my-crate@1.2.3` in registry `my-registry`";
+        assert!(!interpret_cargo_info(false, stderr, "my-crate@1.2.3", "my-registry").unwrap());
+    }
+
+    #[test]
+    fn interpret_cargo_info_surfaces_other_failures() {
+        // An auth/network failure must not be mistaken for "version absent".
+        let stderr = "error: failed to authenticate to registry `my-registry`";
+        let err = interpret_cargo_info(false, stderr, "my-crate@1.2.3", "my-registry")
+            .expect_err("auth failure should surface as an error");
+        assert!(format!("{err}").contains("cargo info failed"));
+    }
+
+    #[test]
+    fn discover_keeps_versionless_private_registry_crate() {
+        // A versionless private-registry crate is a release target, not dropped.
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        fs::write(
+            root.join("Cargo.toml"),
+            "[workspace]\nmembers = [\"crates/*\"]\n",
+        )
+        .unwrap();
+        let crates_dir = root.join("crates");
+        fs::create_dir_all(crates_dir.join("private-lib")).unwrap();
+        fs::write(
+            crates_dir.join("private-lib/Cargo.toml"),
+            "[package]\nname = \"private-lib\"\npublish = [\"my-registry\"]\n",
+        )
+        .unwrap();
+
+        let packages = discover_cargo(root).unwrap();
+        assert!(packages.iter().any(|p| p.name == "private-lib"));
+    }
+}

--- a/crates/sampo-core/src/filters.rs
+++ b/crates/sampo-core/src/filters.rs
@@ -9,7 +9,7 @@ use std::collections::BTreeSet;
 /// Determines whether a package should be ignored based on configuration.
 ///
 /// Rules:
-/// - When `ignore_unpublished` is true, skip packages that are not publishable to crates.io
+/// - When `ignore_unpublished` is true, skip packages that are not publishable to any registry
 /// - When `ignore` contains patterns, skip packages matching by name or workspace-relative path
 pub fn should_ignore_package(cfg: &Config, ws: &Workspace, info: &PackageInfo) -> Result<bool> {
     // 1) ignore_unpublished

--- a/crates/sampo-core/src/publish.rs
+++ b/crates/sampo-core/src/publish.rs
@@ -1505,14 +1505,23 @@ fn main() {
         .unwrap();
         assert!(!adapter.is_publishable(&manifest_false).unwrap());
 
-        // Test publish = ["custom-registry"] (not crates-io)
+        // Test publish = ["custom-registry"] (alternative registry)
         let manifest_custom = temp_dir.path().join("custom.toml");
         fs::write(
             &manifest_custom,
             "[package]\nname=\"test\"\nversion=\"0.1.0\"\npublish = [\"custom-registry\"]\n",
         )
         .unwrap();
-        assert!(!adapter.is_publishable(&manifest_custom).unwrap());
+        assert!(adapter.is_publishable(&manifest_custom).unwrap());
+
+        // Test publish = [] (empty list)
+        let manifest_empty = temp_dir.path().join("empty.toml");
+        fs::write(
+            &manifest_empty,
+            "[package]\nname=\"test\"\nversion=\"0.1.0\"\npublish = []\n",
+        )
+        .unwrap();
+        assert!(!adapter.is_publishable(&manifest_empty).unwrap());
 
         // Test publish = ["crates-io"] (explicitly allowed)
         let manifest_allowed = temp_dir.path().join("allowed.toml");

--- a/crates/sampo/README.md
+++ b/crates/sampo/README.md
@@ -14,7 +14,7 @@ Install Sampo using Cargo:
 cargo install sampo
 ```
 
-Or install from npm (works on Linux, macOS, and Windows):
+Or from npm:
 
 ```bash
 pnpm add -D sampo   && pnpm sampo --help    # or:


### PR DESCRIPTION
## What has changed?

Closes #277. In Cargo (Rust) projects, added support for alternative and private registries, and fixed crates that publish solely to an alternative registry (`publish = ["my-registry"]`) being wrongly marked as non-publishable. `sampo publish` now checks whether a version already exists on the target registry using your Cargo registry configuration and credentials.

## How is it tested?

Unit tests in `cargo_tests.rs` cover the `publish`-field semantics (`false` and `[]` non-publishable; a single alternative registry, multiple registries, and explicit `crates-io` resolved per Cargo's own rules), the registry resolution from the `publish` field, the `cargo info` argv, and the output interpretation (existing version present, missing version absent, other failures surfaced rather than mistaken for absent). The existing `publish`-field test was updated for the corrected gate.

## How is it documented?

Relies on already documented Cargo conventions for alternative registries (`.cargo/config.toml` `[registries]`, `CARGO_REGISTRIES_<NAME>_TOKEN`).