### PR TITLE
feat(core): private Hex registries

### DIFF
--- a/.sampo/changesets/frozen-harbor-vainamoinen.md
+++ b/.sampo/changesets/frozen-harbor-vainamoinen.md
@@ -1,0 +1,7 @@
+---
+cargo/sampo-core: minor
+cargo/sampo: minor
+cargo/sampo-github-action: minor
+---
+
+In Elixir (Hex) projects, added support for private organisations. For packages that declare an `organization` in their `mix.exs` package configuration, `sampo publish` now checks the organisation's repository for already-published versions and authenticates that check with `HEX_API_KEY`.

--- a/crates/sampo-core/src/adapters/hex.rs
+++ b/crates/sampo-core/src/adapters/hex.rs
@@ -43,7 +43,7 @@ impl HexAdapter {
         &self,
         package_name: &str,
         version: &str,
-        _manifest_path: Option<&Path>,
+        manifest_path: Option<&Path>,
     ) -> Result<bool> {
         let name = package_name.trim();
         if name.is_empty() {
@@ -51,6 +51,11 @@ impl HexAdapter {
                 "Package name cannot be empty when checking Hex registry".into(),
             ));
         }
+
+        // Private packages live under an organisation and require authentication; the
+        // public path needs neither.
+        let organization = manifest_path.and_then(mix::read_organization);
+        let api_key = hex_api_key();
 
         let client = Client::builder()
             .timeout(Duration::from_secs(10))
@@ -60,19 +65,29 @@ impl HexAdapter {
                 SampoError::Publish(format!("failed to build HTTP client for Hex: {}", e))
             })?;
 
-        let url = format!("{HEX_API_BASE}/packages/{}/releases/{}", name, version);
+        let url = registry_url(organization.as_deref(), name, version);
         enforce_hex_rate_limit();
-        let response = client.get(&url).send().map_err(|e| {
-            SampoError::Publish(format!(
-                "failed to query Hex registry for '{}': {}",
-                name, e
-            ))
-        })?;
+        let response = version_check_request(&client, &url, api_key.as_deref())
+            .send()
+            .map_err(|e| {
+                SampoError::Publish(format!(
+                    "failed to query Hex registry for '{}': {}",
+                    name, e
+                ))
+            })?;
 
         let status_code = response.status();
         match status_code {
             StatusCode::OK => Ok(true),
-            StatusCode::NOT_FOUND => Ok(false),
+            // Hex hides private packages behind 404, so an unauthenticated 404 for an
+            // organisation is ambiguous: error out rather than assert the version is absent.
+            StatusCode::NOT_FOUND => match (&organization, &api_key) {
+                (Some(org), None) => Err(SampoError::Publish(format!(
+                    "Hex returned 404 for private organisation '{org}'; set HEX_API_KEY to \
+                     check whether '{name}@{version}' is already published"
+                ))),
+                _ => Ok(false),
+            },
             StatusCode::TOO_MANY_REQUESTS => {
                 let retry_after = response
                     .headers()
@@ -85,10 +100,17 @@ impl HexAdapter {
                     name, version, retry_after
                 )))
             }
-            StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => Err(SampoError::Publish(format!(
-                "Hex registry returned {} for '{}@{}'; authentication may be required",
-                status_code, name, version
-            ))),
+            StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => {
+                let hint = if api_key.is_none() {
+                    "; set HEX_API_KEY to authenticate"
+                } else {
+                    ""
+                };
+                Err(SampoError::Publish(format!(
+                    "Hex registry returned {} for '{}@{}'; authentication may be required{}",
+                    status_code, name, version, hint
+                )))
+            }
             other => {
                 let body = response.text().unwrap_or_default();
                 let snippet: String = body.trim().chars().take(300).collect();
@@ -117,6 +139,36 @@ impl HexAdapter {
 
     pub(super) fn regenerate_lockfile(&self, workspace_root: &Path) -> Result<()> {
         mix::regenerate_lockfile(workspace_root)
+    }
+}
+
+fn registry_url(organization: Option<&str>, name: &str, version: &str) -> String {
+    match organization {
+        Some(org) => format!("{HEX_API_BASE}/repos/{org}/packages/{name}/releases/{version}"),
+        None => format!("{HEX_API_BASE}/packages/{name}/releases/{version}"),
+    }
+}
+
+fn hex_api_key() -> Option<String> {
+    resolve_hex_api_key(|key| std::env::var(key).ok())
+}
+
+fn resolve_hex_api_key(lookup: impl Fn(&str) -> Option<String>) -> Option<String> {
+    let trimmed = lookup("HEX_API_KEY")?.trim().to_string();
+    (!trimmed.is_empty()).then_some(trimmed)
+}
+
+/// Hex expects the raw key in `Authorization`, with no `Bearer` prefix.
+/// See https://github.com/hexpm/specifications.
+fn version_check_request(
+    client: &Client,
+    url: &str,
+    api_key: Option<&str>,
+) -> reqwest::blocking::RequestBuilder {
+    let request = client.get(url);
+    match api_key {
+        Some(key) => request.header(reqwest::header::AUTHORIZATION, key),
+        None => request,
     }
 }
 

--- a/crates/sampo-core/src/adapters/hex.rs
+++ b/crates/sampo-core/src/adapters/hex.rs
@@ -86,6 +86,16 @@ impl HexAdapter {
                     "Hex returned 404 for private organisation '{org}'; set HEX_API_KEY to \
                      check whether '{name}@{version}' is already published"
                 ))),
+                // A 404 with a key set is still ambiguous (the key may lack org access),
+                // but proceed as absent since publishing enforces access anyway.
+                (Some(org), Some(_)) => {
+                    eprintln!(
+                        "Warning: Hex returned 404 for '{name}@{version}' in private \
+                         organisation '{org}'; the version may be unpublished, or HEX_API_KEY \
+                         may lack access to the organisation."
+                    );
+                    Ok(false)
+                }
                 _ => Ok(false),
             },
             StatusCode::TOO_MANY_REQUESTS => {
@@ -101,14 +111,16 @@ impl HexAdapter {
                 )))
             }
             StatusCode::UNAUTHORIZED | StatusCode::FORBIDDEN => {
-                let hint = if api_key.is_none() {
-                    "; set HEX_API_KEY to authenticate"
+                // With a key present the request was authenticated and still rejected, so the
+                // key — not its absence — is the likely cause.
+                let detail = if api_key.is_some() {
+                    "HEX_API_KEY may be invalid or lack the required access"
                 } else {
-                    ""
+                    "authentication may be required; set HEX_API_KEY to authenticate"
                 };
                 Err(SampoError::Publish(format!(
-                    "Hex registry returned {} for '{}@{}'; authentication may be required{}",
-                    status_code, name, version, hint
+                    "Hex registry returned {} for '{}@{}'; {}",
+                    status_code, name, version, detail
                 )))
             }
             other => {

--- a/crates/sampo-core/src/adapters/hex/hex_tests.rs
+++ b/crates/sampo-core/src/adapters/hex/hex_tests.rs
@@ -7,6 +7,76 @@ fn version_exists_rejects_empty_name() {
     assert!(format!("{}", err).contains("Package name cannot be empty"));
 }
 
+#[test]
+fn registry_url_uses_repos_path_for_organization() {
+    let url = registry_url(Some("acme"), "example", "1.0.0");
+    assert_eq!(
+        url,
+        "https://hex.pm/api/repos/acme/packages/example/releases/1.0.0"
+    );
+}
+
+#[test]
+fn registry_url_uses_public_path_without_organization() {
+    let url = registry_url(None, "example", "1.0.0");
+    assert_eq!(url, "https://hex.pm/api/packages/example/releases/1.0.0");
+}
+
+#[test]
+fn resolve_hex_api_key_returns_trimmed_value() {
+    let key =
+        resolve_hex_api_key(|name| (name == "HEX_API_KEY").then(|| "  secret-key  ".to_string()));
+    assert_eq!(key.as_deref(), Some("secret-key"));
+}
+
+#[test]
+fn resolve_hex_api_key_none_when_blank() {
+    let key = resolve_hex_api_key(|_| Some("   ".to_string()));
+    assert_eq!(key, None);
+}
+
+#[test]
+fn resolve_hex_api_key_none_when_unset() {
+    let key = resolve_hex_api_key(|_| None);
+    assert_eq!(key, None);
+}
+
+#[test]
+fn version_check_request_attaches_raw_api_key() {
+    let client = Client::new();
+    let request = version_check_request(
+        &client,
+        "https://hex.pm/api/repos/acme/packages/example/releases/1.0.0",
+        Some("secret-key"),
+    )
+    .build()
+    .expect("request should build");
+    let auth = request
+        .headers()
+        .get(reqwest::header::AUTHORIZATION)
+        .expect("authorization header present");
+    assert_eq!(auth.to_str().unwrap(), "secret-key");
+}
+
+#[test]
+fn version_check_request_omits_auth_without_key() {
+    let client = Client::new();
+    let request = version_check_request(
+        &client,
+        "https://hex.pm/api/packages/example/releases/1.0.0",
+        None,
+    )
+    .build()
+    .expect("request should build");
+    assert!(
+        request
+            .headers()
+            .get(reqwest::header::AUTHORIZATION)
+            .is_none(),
+        "expected no authorization header"
+    );
+}
+
 mod constraint_validation {
     use super::*;
     use crate::types::ConstraintCheckResult;

--- a/crates/sampo-core/src/adapters/hex/mix.rs
+++ b/crates/sampo-core/src/adapters/hex/mix.rs
@@ -360,6 +360,7 @@ struct ProjectMetadata {
     version: Option<String>,
     apps_path: Option<PathBuf>,
     has_package_config: bool,
+    organization: Option<String>,
 }
 
 #[derive(Debug, Clone)]
@@ -434,6 +435,7 @@ fn parse_project_metadata(source: &str) -> ProjectMetadata {
     }
 
     metadata.has_package_config = has_package_function(source_bytes, &tree);
+    metadata.organization = parse_package_organization(source, &tree);
 
     metadata
 }
@@ -441,6 +443,37 @@ fn parse_project_metadata(source: &str) -> ProjectMetadata {
 fn has_package_function(source_bytes: &[u8], tree: &Tree) -> bool {
     let calls = find_function_calls(tree, source_bytes, "package");
     !calls.is_empty()
+}
+
+/// Private Hex packages are published under an `organization:` in the `package/0` list.
+fn parse_package_organization(source: &str, tree: &Tree) -> Option<String> {
+    let source_bytes = source.as_bytes();
+    let function = find_function_call(tree, source_bytes, "package")?;
+    let keywords = function_body_keywords(function)?;
+    let mut cursor = keywords.walk();
+    for pair in keywords.named_children(&mut cursor) {
+        if pair.kind() != "pair" {
+            continue;
+        }
+        let Some((key_node, value_node)) = pair_key_value(pair) else {
+            continue;
+        };
+        if keyword_name(source_bytes, key_node).as_deref() != Some("organization") {
+            continue;
+        }
+        if let Some(literal) = parse_string_literal_node(source, value_node) {
+            let value = literal.value.trim();
+            if !value.is_empty() {
+                return Some(value.to_string());
+            }
+        }
+    }
+    None
+}
+
+pub(super) fn read_organization(manifest_path: &Path) -> Option<String> {
+    let text = fs::read_to_string(manifest_path).ok()?;
+    parse_project_metadata(&text).organization
 }
 
 /// Checks if a node is a module attribute reference like `@version` (not a definition).

--- a/crates/sampo-core/src/adapters/hex/mix/mix_tests.rs
+++ b/crates/sampo-core/src/adapters/hex/mix/mix_tests.rs
@@ -44,6 +44,121 @@ end
 }
 
 #[test]
+fn read_organization_extracts_org_from_package_config() {
+    let temp = tempfile::tempdir().unwrap();
+    let manifest = temp.path().join("mix.exs");
+    write_file(
+        &manifest,
+        r#"
+defmodule Example.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :example,
+      version: "0.1.0",
+      package: package()
+    ]
+  end
+
+  defp package do
+    [
+      organization: "acme",
+      licenses: ["Apache-2.0"]
+    ]
+  end
+end
+"#,
+    );
+
+    assert_eq!(read_organization(&manifest).as_deref(), Some("acme"));
+}
+
+#[test]
+fn read_organization_none_when_package_has_no_organization() {
+    let temp = tempfile::tempdir().unwrap();
+    let manifest = temp.path().join("mix.exs");
+    write_file(
+        &manifest,
+        r#"
+defmodule Example.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :example,
+      version: "0.1.0",
+      package: package()
+    ]
+  end
+
+  defp package do
+    [
+      licenses: ["Apache-2.0"]
+    ]
+  end
+end
+"#,
+    );
+
+    assert_eq!(read_organization(&manifest), None);
+}
+
+#[test]
+fn read_organization_none_for_blank_organization() {
+    let temp = tempfile::tempdir().unwrap();
+    let manifest = temp.path().join("mix.exs");
+    write_file(
+        &manifest,
+        r#"
+defmodule Example.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :example,
+      version: "0.1.0",
+      package: package()
+    ]
+  end
+
+  defp package do
+    [
+      organization: "  ",
+      licenses: ["Apache-2.0"]
+    ]
+  end
+end
+"#,
+    );
+
+    assert_eq!(read_organization(&manifest), None);
+}
+
+#[test]
+fn read_organization_none_without_package_config() {
+    let temp = tempfile::tempdir().unwrap();
+    let manifest = temp.path().join("mix.exs");
+    write_file(
+        &manifest,
+        r#"
+defmodule Example.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :example,
+      version: "0.1.0"
+    ]
+  end
+end
+"#,
+    );
+
+    assert_eq!(read_organization(&manifest), None);
+}
+
+#[test]
 fn discover_skips_non_publishable_versionless_app() {
     let temp = tempfile::tempdir().unwrap();
     let root = temp.path();


### PR DESCRIPTION
## What has changed?

Closes #279 . In Elixir (Hex) projects, added support for private organisations. For packages that declare an `organization` in their `mix.exs` package configuration, `sampo publish` now checks the organisation's repository for already-published versions and authenticates that check with `HEX_API_KEY`.

## How is it tested?

Unit tests in `hex_tests.rs` cover the API-key resolution (trimmed, blank → none, unset → none), the request wiring (raw key in `Authorization` with no `Bearer` prefix when a key is present, header absent without), and the registry URL selection (organisation → `/repos/<org>/…`, none → the public endpoint). Tests in `mix_tests.rs` cover parsing `organization:` from the `mix.exs` package config (present, absent, blank → none, and no package config).

## How is it documented?

Relies on Hex's already documented `HEX_API_KEY` convention and the `organization` key in the `mix.exs` package config.