### PR TITLE
feat(core): private PyPI registries

### DIFF
--- a/.sampo/changesets/silent-harbor-lemminkainen.md
+++ b/.sampo/changesets/silent-harbor-lemminkainen.md
@@ -1,0 +1,7 @@
+---
+cargo/sampo-core: minor
+cargo/sampo: minor
+cargo/sampo-github-action: minor
+---
+
+In Python (PyPI) projects, added support for private indexes. For packages that declare a uv index with a `publish-url` in `pyproject.toml`, `sampo publish` now routes the upload to that index via `uv publish --index`, which resolves the upload URL, credentials, and already-published checks from your uv configuration.

--- a/crates/sampo-core/src/adapters/pypi.rs
+++ b/crates/sampo-core/src/adapters/pypi.rs
@@ -46,13 +46,22 @@ impl PyPIAdapter {
         &self,
         package_name: &str,
         version: &str,
-        _manifest_path: Option<&Path>,
+        manifest_path: Option<&Path>,
     ) -> Result<bool> {
         let name = package_name.trim();
         if name.is_empty() {
             return Err(SampoError::Publish(
                 "Package name cannot be empty when checking PyPI registry".into(),
             ));
+        }
+
+        // A package routed to a private uv index isn't on public PyPI; querying
+        // there risks a false positive from a same-named public package. Let
+        // `uv publish --index` own the idempotent re-run.
+        if let Some(path) = manifest_path
+            && pip::has_private_publish_index(path)
+        {
+            return Ok(false);
         }
 
         let client = Client::builder()

--- a/crates/sampo-core/src/adapters/pypi/pip.rs
+++ b/crates/sampo-core/src/adapters/pypi/pip.rs
@@ -242,6 +242,10 @@ pub(super) fn publish(manifest_path: &Path, dry_run: bool, extra_args: &[String]
         )));
     }
 
+    // Resolve before building so an ambiguous manifest fails fast rather than
+    // after wasting a build.
+    let publish_index = resolve_publish_index(&text, manifest_path, extra_args)?;
+
     // Clean previous build artifacts
     let dist_dir = manifest_dir.join("dist");
     if dist_dir.exists() {
@@ -281,6 +285,12 @@ pub(super) fn publish(manifest_path: &Path, dry_run: bool, extra_args: &[String]
     // Actual upload using uv publish
     let mut publish_cmd = Command::new("uv");
     publish_cmd.arg("publish").current_dir(manifest_dir);
+
+    // uv resolves the upload URL, check-url, and credentials from its own
+    // configuration; Sampo handles no secrets.
+    if let Some(index) = &publish_index {
+        publish_cmd.arg("--index").arg(index);
+    }
 
     if !extra_args.is_empty() {
         publish_cmd.args(extra_args);
@@ -496,6 +506,153 @@ fn parse_uv_workspace_config(source: &str) -> UvWorkspaceConfig {
         .filter(|v: &Vec<String>| !v.is_empty());
 
     UvWorkspaceConfig { members, exclude }
+}
+
+/// Which uv index `sampo publish` should target, derived from `[[tool.uv.index]]`
+/// entries that declare a `publish-url`.
+#[derive(Debug, PartialEq, Eq)]
+enum PublishIndex {
+    /// No publish target; publish to the default registry (PyPI).
+    Default,
+    Named(String),
+    /// Several publish targets; the user must disambiguate.
+    Ambiguous(Vec<String>),
+    /// Publish target without a `name`, so it cannot be addressed.
+    Unnamed,
+}
+
+/// Classify an index entry: `None` when it has no (non-blank) `publish-url`,
+/// `Some(None)` for a publish target without an addressable name, and
+/// `Some(Some(name))` otherwise.
+fn publish_target_name(name: Option<&str>, publish_url: Option<&str>) -> Option<Option<String>> {
+    if publish_url.is_none_or(|url| url.trim().is_empty()) {
+        return None;
+    }
+    Some(
+        name.map(str::trim)
+            .filter(|n| !n.is_empty())
+            .map(str::to_string),
+    )
+}
+
+/// Parse the uv index declarations and select the publish target.
+///
+/// uv never picks a publish index on its own. Both the `[[tool.uv.index]]` block
+/// form and the inline-table array (`index = [{ ... }]`) are accepted; missing
+/// either would let a private package fall through to public PyPI, which is not
+/// recoverable. An unnamed or ambiguous target is refused rather than guessed.
+fn parse_publish_index(source: &str) -> PublishIndex {
+    let Ok(doc) = source.parse::<DocumentMut>() else {
+        return PublishIndex::Default;
+    };
+
+    let Some(index_item) = doc
+        .get("tool")
+        .and_then(|t| t.as_table())
+        .and_then(|t| t.get("uv"))
+        .and_then(|t| t.as_table())
+        .and_then(|t| t.get("index"))
+    else {
+        return PublishIndex::Default;
+    };
+
+    let mut targets: Vec<Option<String>> = Vec::new();
+    if let Some(tables) = index_item.as_array_of_tables() {
+        for table in tables {
+            if let Some(target) = publish_target_name(
+                table.get("name").and_then(Item::as_str),
+                table.get("publish-url").and_then(Item::as_str),
+            ) {
+                targets.push(target);
+            }
+        }
+    } else if let Some(array) = index_item.as_array() {
+        for value in array.iter() {
+            if let Some(inline) = value.as_inline_table()
+                && let Some(target) = publish_target_name(
+                    inline.get("name").and_then(Value::as_str),
+                    inline.get("publish-url").and_then(Value::as_str),
+                )
+            {
+                targets.push(target);
+            }
+        }
+    }
+
+    match targets.len() {
+        0 => PublishIndex::Default,
+        1 => match targets.into_iter().next().flatten() {
+            Some(name) => PublishIndex::Named(name),
+            None => PublishIndex::Unnamed,
+        },
+        // Surface unnamed candidates too, so the error reflects the real conflict.
+        _ => PublishIndex::Ambiguous(
+            targets
+                .into_iter()
+                .map(|name| name.unwrap_or_else(|| "<unnamed>".to_string()))
+                .collect(),
+        ),
+    }
+}
+
+/// Resolve the `--index` to inject into `uv publish`. A destination chosen via
+/// `extra_args` takes precedence: Sampo yields `None` and does not second-guess
+/// an otherwise ambiguous manifest.
+fn resolve_publish_index(
+    source: &str,
+    manifest_path: &Path,
+    extra_args: &[String],
+) -> Result<Option<String>> {
+    if extra_args_select_index(extra_args) {
+        return Ok(None);
+    }
+    publish_index_arg(source, manifest_path)
+}
+
+/// Resolve the `--index` value to forward to `uv publish`, or `None` for the
+/// default registry. Errors when the publish target cannot be picked safely.
+fn publish_index_arg(source: &str, manifest_path: &Path) -> Result<Option<String>> {
+    match parse_publish_index(source) {
+        PublishIndex::Default => Ok(None),
+        PublishIndex::Named(name) => Ok(Some(name)),
+        PublishIndex::Unnamed => Err(SampoError::Publish(format!(
+            "Manifest {} declares a uv index with a publish-url but no name; \
+             add a `name` so Sampo can target it with `uv publish --index`",
+            manifest_path.display()
+        ))),
+        PublishIndex::Ambiguous(mut names) => {
+            names.sort();
+            Err(SampoError::Publish(format!(
+                "Manifest {} declares multiple uv indexes with a publish-url ({}); \
+                 Sampo cannot choose which to publish to. Select one explicitly, \
+                 e.g. `sampo publish --pypi-args --index <name>`",
+                manifest_path.display(),
+                names.join(", ")
+            )))
+        }
+    }
+}
+
+/// Whether the user already selected a publish destination through `extra_args`.
+///
+/// `--index` is mutually exclusive with `--publish-url`/`--check-url` in uv, so
+/// Sampo must not inject its own when any of them is present.
+fn extra_args_select_index(extra_args: &[String]) -> bool {
+    const INDEX_FLAGS: [&str; 3] = ["--index", "--publish-url", "--check-url"];
+    extra_args.iter().any(|arg| {
+        INDEX_FLAGS
+            .iter()
+            .any(|flag| arg == flag || arg.starts_with(&format!("{flag}=")))
+    })
+}
+
+/// Whether the manifest routes publishing to a private uv index. An ambiguous
+/// manifest counts as private: it is not destined for public PyPI.
+pub(super) fn has_private_publish_index(manifest_path: &Path) -> bool {
+    let Ok(text) = fs::read_to_string(manifest_path) else {
+        return false;
+    };
+    !matches!(parse_publish_index(&text), PublishIndex::Default)
 }
 
 /// Expand a member pattern (plain path or glob) into concrete paths containing pyproject.toml

--- a/crates/sampo-core/src/adapters/pypi/pip/pip_tests.rs
+++ b/crates/sampo-core/src/adapters/pypi/pip/pip_tests.rs
@@ -1655,6 +1655,248 @@ version = "0.1.0"
     assert!(paths.iter().next().unwrap().ends_with("valid-pkg"));
 }
 
+#[test]
+fn parse_publish_index_default_when_no_index() {
+    let source = r#"
+[project]
+name = "pkg"
+version = "1.0.0"
+"#;
+    assert_eq!(parse_publish_index(source), PublishIndex::Default);
+}
+
+#[test]
+fn parse_publish_index_default_when_index_lacks_publish_url() {
+    let source = r#"
+[[tool.uv.index]]
+name = "internal"
+url = "https://example.com/simple/"
+"#;
+    assert_eq!(parse_publish_index(source), PublishIndex::Default);
+}
+
+#[test]
+fn parse_publish_index_named_for_single_publish_url() {
+    let source = r#"
+[[tool.uv.index]]
+name = "internal"
+url = "https://example.com/simple/"
+publish-url = "https://example.com/upload/"
+"#;
+    assert_eq!(
+        parse_publish_index(source),
+        PublishIndex::Named("internal".to_string())
+    );
+}
+
+#[test]
+fn parse_publish_index_named_ignores_resolution_only_siblings() {
+    let source = r#"
+[[tool.uv.index]]
+name = "mirror"
+url = "https://mirror.example.com/simple/"
+
+[[tool.uv.index]]
+name = "private"
+url = "https://private.example.com/simple/"
+publish-url = "https://private.example.com/upload/"
+"#;
+    assert_eq!(
+        parse_publish_index(source),
+        PublishIndex::Named("private".to_string())
+    );
+}
+
+#[test]
+fn parse_publish_index_ignores_blank_publish_url() {
+    let source = r#"
+[[tool.uv.index]]
+name = "internal"
+publish-url = "   "
+"#;
+    assert_eq!(parse_publish_index(source), PublishIndex::Default);
+}
+
+#[test]
+fn parse_publish_index_ambiguous_for_multiple_publish_urls() {
+    let source = r#"
+[[tool.uv.index]]
+name = "alpha"
+publish-url = "https://alpha.example.com/upload/"
+
+[[tool.uv.index]]
+name = "beta"
+publish-url = "https://beta.example.com/upload/"
+"#;
+    assert_eq!(
+        parse_publish_index(source),
+        PublishIndex::Ambiguous(vec!["alpha".to_string(), "beta".to_string()])
+    );
+}
+
+#[test]
+fn publish_index_arg_errors_when_ambiguous() {
+    let source = r#"
+[[tool.uv.index]]
+name = "alpha"
+publish-url = "https://alpha.example.com/upload/"
+
+[[tool.uv.index]]
+name = "beta"
+publish-url = "https://beta.example.com/upload/"
+"#;
+    let err = publish_index_arg(source, Path::new("/tmp/pyproject.toml"))
+        .expect_err("expected ambiguous indexes to error");
+    let message = err.to_string();
+    assert!(message.contains("multiple uv indexes"));
+    assert!(message.contains("alpha, beta"));
+}
+
+#[test]
+fn publish_index_arg_resolves_single_target() {
+    let source = r#"
+[[tool.uv.index]]
+name = "private"
+publish-url = "https://private.example.com/upload/"
+"#;
+    let resolved = publish_index_arg(source, Path::new("/tmp/pyproject.toml")).unwrap();
+    assert_eq!(resolved, Some("private".to_string()));
+}
+
+#[test]
+fn resolve_publish_index_yields_to_user_override() {
+    let source = r#"
+[[tool.uv.index]]
+name = "alpha"
+publish-url = "https://alpha.example.com/upload/"
+
+[[tool.uv.index]]
+name = "beta"
+publish-url = "https://beta.example.com/upload/"
+"#;
+    let extra = vec!["--index".to_string(), "alpha".to_string()];
+    let resolved = resolve_publish_index(source, Path::new("/tmp/pyproject.toml"), &extra).unwrap();
+    assert_eq!(resolved, None);
+}
+
+#[test]
+fn resolve_publish_index_resolves_named_without_override() {
+    let source = r#"
+[[tool.uv.index]]
+name = "private"
+publish-url = "https://private.example.com/upload/"
+"#;
+    let resolved = resolve_publish_index(source, Path::new("/tmp/pyproject.toml"), &[]).unwrap();
+    assert_eq!(resolved, Some("private".to_string()));
+}
+
+#[test]
+fn parse_publish_index_ambiguous_lists_unnamed_targets() {
+    let source = r#"
+[[tool.uv.index]]
+name = "alpha"
+publish-url = "https://alpha.example.com/upload/"
+
+[[tool.uv.index]]
+publish-url = "https://beta.example.com/upload/"
+"#;
+    assert_eq!(
+        parse_publish_index(source),
+        PublishIndex::Ambiguous(vec!["alpha".to_string(), "<unnamed>".to_string()])
+    );
+}
+
+#[test]
+fn parse_publish_index_handles_inline_table_form() {
+    let source = r#"
+[tool.uv]
+index = [
+    { name = "private", url = "https://private.example.com/simple/", publish-url = "https://private.example.com/upload/" },
+]
+"#;
+    assert_eq!(
+        parse_publish_index(source),
+        PublishIndex::Named("private".to_string())
+    );
+}
+
+#[test]
+fn parse_publish_index_unnamed_when_publish_url_lacks_name() {
+    let source = r#"
+[[tool.uv.index]]
+publish-url = "https://private.example.com/upload/"
+"#;
+    assert_eq!(parse_publish_index(source), PublishIndex::Unnamed);
+}
+
+#[test]
+fn publish_index_arg_errors_when_unnamed() {
+    let source = r#"
+[[tool.uv.index]]
+publish-url = "https://private.example.com/upload/"
+"#;
+    let err = publish_index_arg(source, Path::new("/tmp/pyproject.toml"))
+        .expect_err("a publish-url without a name cannot be targeted");
+    assert!(err.to_string().contains("no name"));
+}
+
+#[test]
+fn extra_args_select_index_detects_user_flags() {
+    assert!(extra_args_select_index(&[
+        "--index".to_string(),
+        "foo".to_string()
+    ]));
+    assert!(extra_args_select_index(&["--index=foo".to_string()]));
+    assert!(extra_args_select_index(&["--publish-url".to_string()]));
+    assert!(extra_args_select_index(&[
+        "--check-url=https://x/simple/".to_string()
+    ]));
+}
+
+#[test]
+fn extra_args_select_index_false_for_unrelated_flags() {
+    assert!(!extra_args_select_index(&[]));
+    assert!(!extra_args_select_index(&[
+        "--no-attestations".to_string(),
+        "--token".to_string(),
+        "secret".to_string(),
+    ]));
+}
+
+#[test]
+fn has_private_publish_index_true_for_publish_url_manifest() {
+    let temp = tempfile::tempdir().unwrap();
+    let manifest = temp.path().join("pyproject.toml");
+    write_file(
+        &manifest,
+        r#"
+[project]
+name = "pkg"
+version = "1.0.0"
+
+[[tool.uv.index]]
+name = "private"
+publish-url = "https://private.example.com/upload/"
+"#,
+    );
+    assert!(has_private_publish_index(&manifest));
+}
+
+#[test]
+fn has_private_publish_index_false_for_public_manifest() {
+    let temp = tempfile::tempdir().unwrap();
+    let manifest = temp.path().join("pyproject.toml");
+    write_file(
+        &manifest,
+        r#"
+[project]
+name = "pkg"
+version = "1.0.0"
+"#,
+    );
+    assert!(!has_private_publish_index(&manifest));
+}
+
 mod constraint_validation {
     use super::*;
     use crate::types::ConstraintCheckResult;

--- a/crates/sampo-core/src/adapters/pypi/pypi_tests.rs
+++ b/crates/sampo-core/src/adapters/pypi/pypi_tests.rs
@@ -9,6 +9,30 @@ fn version_exists_rejects_empty_name() {
 }
 
 #[test]
+fn version_exists_defers_to_uv_for_private_index() {
+    let dir = tempfile::tempdir().unwrap();
+    let manifest = dir.path().join("pyproject.toml");
+    std::fs::write(
+        &manifest,
+        r#"
+[project]
+name = "private-pkg"
+version = "1.0.0"
+
+[[tool.uv.index]]
+name = "private"
+publish-url = "https://private.example.com/upload/"
+"#,
+    )
+    .unwrap();
+
+    let exists = PyPIAdapter
+        .version_exists("private-pkg", "1.0.0", Some(manifest.as_path()))
+        .expect("private index should defer without erroring");
+    assert!(!exists);
+}
+
+#[test]
 fn normalize_package_name_converts_underscores_and_dots() {
     assert_eq!(normalize_package_name("My_Package"), "my-package");
     assert_eq!(normalize_package_name("some.package"), "some-package");


### PR DESCRIPTION
## What has changed?

Closes #280. In Python (PyPI) projects, added support for private indexes. For packages that declare a uv index with a `publish-url` in `pyproject.toml`, `sampo publish` routes the upload to that index via `uv publish --index`, which resolves the upload URL, credentials, and already-published check from your uv configuration. 

Two choices worth noting: the version check defers to uv for private indexes rather than probing public PyPI, and when several indexes declare a `publish-url` publishing fails fast rather than guess the target.

## How is it tested?

Unit tests in `pip_tests.rs` cover the index resolution (none, single, ambiguous, unnamed, blank `publish-url`, resolution-only siblings, and the inline-table form), the user override taking precedence, and the `--index` conflict detection; `pypi_tests.rs` covers the private-index short-circuit in the version check.

## How is it documented?

Relies on uv's already documented `[[tool.uv.index]]` `publish-url` and credential conventions.