### PR TITLE
feat(core): private Packagist registries

### DIFF
--- a/.sampo/changesets/distant-harbor-kullervo.md
+++ b/.sampo/changesets/distant-harbor-kullervo.md
@@ -1,0 +1,7 @@
+---
+cargo/sampo-core: minor
+cargo/sampo: minor
+cargo/sampo-github-action: minor
+---
+
+In PHP (Packagist) projects, added support for private registries. Packages resolved through a private or alternative Composer registry (a `type: "composer"` repository in `composer.json`, or `packagist.org` disabled) no longer have their already-published check run against public Packagist. As private Composer registries (Private Packagist, Satis) stay VCS-based, `sampo publish` defers to the git-tag push that drives the registry update.

--- a/crates/sampo-core/src/adapters/packagist.rs
+++ b/crates/sampo-core/src/adapters/packagist.rs
@@ -104,13 +104,22 @@ impl PackagistAdapter {
         &self,
         package_name: &str,
         version: &str,
-        _manifest_path: Option<&Path>,
+        manifest_path: Option<&Path>,
     ) -> Result<bool> {
         let name = package_name.trim();
         if name.is_empty() {
             return Err(SampoError::Publish(
                 "Package name cannot be empty when checking Packagist registry".into(),
             ));
+        }
+
+        // A package on a private/alternative registry isn't on public Packagist,
+        // so the public version check would be meaningless (or a false positive
+        // against a same-named public package). Defer to the git-tag push.
+        if let Some(path) = manifest_path
+            && has_private_composer_repository(path)
+        {
+            return Ok(false);
         }
 
         enforce_packagist_rate_limit();
@@ -410,6 +419,72 @@ pub(super) fn check_dependency_constraint(
             reason: format!("unparseable constraint '{}'", trimmed),
         }),
     }
+}
+
+/// Whether `composer.json` routes resolution through a private/alternative
+/// registry rather than public Packagist.
+///
+/// A `vcs` repository (a single dependency's source) is deliberately not
+/// treated as private: it doesn't change which registry holds this package's
+/// version metadata.
+pub(super) fn has_private_composer_repository(manifest_path: &Path) -> bool {
+    let Ok(text) = fs::read_to_string(manifest_path) else {
+        return false;
+    };
+    serde_json::from_str::<JsonValue>(&text)
+        .map(|manifest| manifest_uses_private_registry(&manifest))
+        .unwrap_or(false)
+}
+
+/// Composer accepts `repositories` as either an array of definitions or an
+/// object keyed by repository name; both forms are handled here.
+fn manifest_uses_private_registry(manifest: &JsonValue) -> bool {
+    let Some(repositories) = manifest.get("repositories") else {
+        return false;
+    };
+    match repositories {
+        JsonValue::Array(items) => items.iter().any(is_private_repository_entry),
+        JsonValue::Object(map) => map.iter().any(|(key, value)| {
+            disables_packagist(key, value) || is_private_repository_entry(value)
+        }),
+        _ => false,
+    }
+}
+
+fn disables_packagist(key: &str, value: &JsonValue) -> bool {
+    matches!(key, "packagist" | "packagist.org") && value.as_bool() == Some(false)
+}
+
+fn is_private_repository_entry(entry: &JsonValue) -> bool {
+    let Some(obj) = entry.as_object() else {
+        return false;
+    };
+    if obj
+        .iter()
+        .any(|(key, value)| disables_packagist(key, value))
+    {
+        return true;
+    }
+    if obj.get("type").and_then(JsonValue::as_str) == Some("composer") {
+        return obj
+            .get("url")
+            .and_then(JsonValue::as_str)
+            .is_some_and(|url| !is_packagist_url(url));
+    }
+    false
+}
+
+fn is_packagist_url(url: &str) -> bool {
+    let after_scheme = url
+        .strip_prefix("https://")
+        .or_else(|| url.strip_prefix("http://"))
+        .unwrap_or(url);
+    // Match the host exactly so a look-alike like `packagist.org.acme.test` is
+    // treated as private rather than public Packagist.
+    let authority = after_scheme.split(['/', '?', '#']).next().unwrap_or("");
+    let host = authority.rsplit('@').next().unwrap_or(authority);
+    let host = host.split(':').next().unwrap_or(host).to_ascii_lowercase();
+    host == "packagist.org" || host == "repo.packagist.org"
 }
 
 fn enforce_packagist_rate_limit() {

--- a/crates/sampo-core/src/adapters/packagist/packagist_tests.rs
+++ b/crates/sampo-core/src/adapters/packagist/packagist_tests.rs
@@ -326,6 +326,129 @@ fn is_publishable_empty_version() {
     assert!(!result);
 }
 
+#[test]
+fn version_exists_skips_private_composer_registry() {
+    let temp = tempfile::tempdir().unwrap();
+    let manifest = r#"{
+    "name": "vendor/package",
+    "version": "1.0.0",
+    "repositories": [
+        { "type": "composer", "url": "https://repo.packagist.com/acme/" }
+    ]
+}"#;
+    let path = temp.path().join("composer.json");
+    std::fs::write(&path, manifest).unwrap();
+
+    // Must short-circuit before any network call.
+    let exists = PackagistAdapter
+        .version_exists("vendor/package", "1.0.0", Some(path.as_path()))
+        .expect("private registry should defer without erroring");
+    assert!(!exists);
+}
+
+#[test]
+fn version_exists_skips_when_packagist_disabled() {
+    let temp = tempfile::tempdir().unwrap();
+    let manifest = r#"{
+    "name": "vendor/package",
+    "version": "1.0.0",
+    "repositories": {
+        "packagist.org": false
+    }
+}"#;
+    let path = temp.path().join("composer.json");
+    std::fs::write(&path, manifest).unwrap();
+
+    let exists = PackagistAdapter
+        .version_exists("vendor/package", "1.0.0", Some(path.as_path()))
+        .expect("disabled packagist should defer without erroring");
+    assert!(!exists);
+}
+
+mod private_registry_detection {
+    use super::*;
+
+    fn detects(manifest: &str) -> bool {
+        let value = serde_json::from_str(manifest).unwrap();
+        manifest_uses_private_registry(&value)
+    }
+
+    #[test]
+    fn array_composer_repository_on_other_host() {
+        assert!(detects(
+            r#"{ "repositories": [{ "type": "composer", "url": "https://repo.packagist.com/acme/" }] }"#
+        ));
+    }
+
+    #[test]
+    fn named_object_composer_repository() {
+        assert!(detects(
+            r#"{ "repositories": { "acme": { "type": "composer", "url": "https://satis.acme.test/" } } }"#
+        ));
+    }
+
+    #[test]
+    fn packagist_disabled_in_array() {
+        assert!(detects(
+            r#"{ "repositories": [{ "packagist.org": false }] }"#
+        ));
+    }
+
+    #[test]
+    fn packagist_disabled_in_object() {
+        assert!(detects(r#"{ "repositories": { "packagist.org": false } }"#));
+    }
+
+    #[test]
+    fn legacy_packagist_key_disabled() {
+        // The pre-Composer-1.0 `"packagist"` toggle is still honored.
+        assert!(detects(r#"{ "repositories": { "packagist": false } }"#));
+    }
+
+    #[test]
+    fn lookalike_packagist_host_is_private() {
+        assert!(detects(
+            r#"{ "repositories": [{ "type": "composer", "url": "https://packagist.org.acme.test/" }] }"#
+        ));
+    }
+
+    #[test]
+    fn malformed_manifest_does_not_short_circuit() {
+        // A parse failure must not silently defer every publish.
+        let temp = tempfile::tempdir().unwrap();
+        let path = temp.path().join("composer.json");
+        std::fs::write(&path, "{ not valid json").unwrap();
+        assert!(!has_private_composer_repository(&path));
+    }
+
+    #[test]
+    fn composer_repository_on_public_packagist_is_not_private() {
+        assert!(!detects(
+            r#"{ "repositories": [{ "type": "composer", "url": "https://repo.packagist.org" }] }"#
+        ));
+    }
+
+    #[test]
+    fn vcs_repository_is_not_private() {
+        // A single dependency's source doesn't change this package's registry.
+        assert!(!detects(
+            r#"{ "repositories": [{ "type": "vcs", "url": "https://github.com/acme/fork" }] }"#
+        ));
+    }
+
+    #[test]
+    fn no_repositories_field() {
+        assert!(!detects(
+            r#"{ "name": "vendor/package", "version": "1.0.0" }"#
+        ));
+    }
+
+    #[test]
+    fn empty_repositories_array() {
+        assert!(!detects(r#"{ "repositories": [] }"#));
+    }
+}
+
 mod constraint_validation {
     use super::*;
     use crate::types::ConstraintCheckResult;


### PR DESCRIPTION
## What has changed?

Closes #281 . In PHP (Packagist) projects, added support for private registries. Packages resolved through a private or alternative Composer registry (a `type: "composer"` repository in `composer.json`, or `packagist.org` disabled) no longer have their already-published check run against public Packagist. As private Composer registries (Private Packagist, Satis) stay VCS-based, `sampo publish` defers to the git-tag push that drives the registry update.

## How is it tested?

13 new unit tests in `packagist_tests.rs` cover the `version_exists` short-circuit (private composer repo; `packagist.org` disabled) and the detection matrix: array and named-object `repositories` forms, the disable toggle including the legacy `"packagist"` key, a look-alike host (`packagist.org.acme.test`), the public-packagist / `vcs` / empty negatives, and malformed JSON not short-circuiting.

## How is it documented?

No new config, env var, or flag: detection is automatic from `composer.json`, consistent with the Cargo/npm/Hex/PyPI sub-issues.