### PR TITLE
fix(core): release planning guards and hermetic publish tests

### DIFF
--- a/.sampo/changesets/eager-smith-ukko.md
+++ b/.sampo/changesets/eager-smith-ukko.md
@@ -1,0 +1,6 @@
+---
+cargo/sampo-core: patch
+cargo/sampo: patch
+---
+
+Fixed `packages.fixed` group members being silently released at different bump levels when another changeset or a `packages.linked` group raised one of them.

--- a/.sampo/changesets/stalwart-smith-ilmatar.md
+++ b/.sampo/changesets/stalwart-smith-ilmatar.md
@@ -1,0 +1,7 @@
+---
+cargo/sampo: minor
+cargo/sampo-core: minor
+cargo/sampo-github-action: minor
+---
+
+**⚠️ breaking change:** Sampo now refuses to release a package whose version it cannot parse or bump (for example a PEP 440 `1.0.0.post1`), instead of planning a do-nothing release that consumed the changeset and wrote a changelog entry under the unchanged version. A run that used to succeed while silently skipping such a package now fails with the package and version named, leaving manifests untouched and no changeset consumed; fix its version, or exclude it with `packages.ignore`. The same validation now runs before `sampo pre enter`'s label switch: a refused entry (invalid label, unbumpable version) used to exit pre-release mode and move preserved changesets back before failing; it now leaves the workspace untouched.

--- a/crates/sampo-core/src/adapters/cargo.rs
+++ b/crates/sampo-core/src/adapters/cargo.rs
@@ -5,6 +5,8 @@ use crate::types::{PackageInfo, PackageKind, Workspace};
 use cargo_metadata::MetadataCommand;
 use rustc_hash::FxHashSet;
 use semver::{Version, VersionReq};
+#[cfg(test)]
+use std::cell::RefCell;
 use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::fs;
 use std::path::{Component, Path, PathBuf};
@@ -13,6 +15,44 @@ use std::time::Duration;
 use toml_edit::{DocumentMut, InlineTable, Item, Table, Value};
 
 const CARGO_MANIFEST: &str = "Cargo.toml";
+
+#[cfg(test)]
+thread_local! {
+    static CRATES_IO_API_BASE_OVERRIDE: RefCell<Option<String>> = const { RefCell::new(None) };
+}
+
+#[cfg(test)]
+pub(crate) struct CratesIoApiBaseOverrideGuard {
+    previous: Option<String>,
+}
+
+/// Point the crates.io existence check at a local stand-in: the real API rate-limits
+/// busy IPs, which made network-dependent tests flaky.
+#[cfg(test)]
+pub(crate) fn override_crates_io_api_base_for_tests(base: &str) -> CratesIoApiBaseOverrideGuard {
+    let previous =
+        CRATES_IO_API_BASE_OVERRIDE.with(|cell| cell.borrow_mut().replace(base.to_string()));
+    CratesIoApiBaseOverrideGuard { previous }
+}
+
+#[cfg(test)]
+impl Drop for CratesIoApiBaseOverrideGuard {
+    fn drop(&mut self) {
+        CRATES_IO_API_BASE_OVERRIDE.with(|cell| {
+            let mut slot = cell.borrow_mut();
+            if let Some(prev) = self.previous.take() {
+                slot.replace(prev);
+            } else {
+                slot.take();
+            }
+        });
+    }
+}
+
+#[cfg(test)]
+fn crates_io_api_base_override() -> Option<String> {
+    CRATES_IO_API_BASE_OVERRIDE.with(|cell| cell.borrow().clone())
+}
 
 /// Stateless adapter for all Cargo operations (discovery, publish, registry, lockfile).
 pub(super) struct CargoAdapter;
@@ -395,7 +435,12 @@ fn interpret_cargo_info(success: bool, stderr: &str, spec: &str, registry: &str)
 /// Query crates.io API to check if a specific version already exists.
 fn version_exists_on_crates_io(crate_name: &str, version: &str) -> Result<bool> {
     // Query crates.io: https://crates.io/api/v1/crates/<name>/<version>
-    let url = format!("https://crates.io/api/v1/crates/{}/{}", crate_name, version);
+    #[cfg(test)]
+    let base =
+        crates_io_api_base_override().unwrap_or_else(|| "https://crates.io/api/v1".to_string());
+    #[cfg(not(test))]
+    let base = "https://crates.io/api/v1".to_string();
+    let url = format!("{}/crates/{}/{}", base, crate_name, version);
 
     let client = reqwest::blocking::Client::builder()
         .timeout(Duration::from_secs(10))

--- a/crates/sampo-core/src/adapters/npm.rs
+++ b/crates/sampo-core/src/adapters/npm.rs
@@ -927,7 +927,11 @@ fn interpret_npm_view(success: bool, stdout: &str, stderr: &str, spec: &str) -> 
 
 fn enforce_registry_rate_limit() {
     let lock = REGISTRY_LAST_CALL.get_or_init(|| Mutex::new(None));
-    let mut guard = lock.lock().unwrap();
+    // Recover from poisoning: the guarded Instant stays valid even if a holder panicked.
+    let mut guard = match lock.lock() {
+        Ok(guard) => guard,
+        Err(poisoned) => poisoned.into_inner(),
+    };
     let now = Instant::now();
     if let Some(last) = *guard {
         let elapsed = now.saturating_duration_since(last);

--- a/crates/sampo-core/src/lib.rs
+++ b/crates/sampo-core/src/lib.rs
@@ -33,6 +33,7 @@ pub use git::current_branch;
 pub use markdown::format_markdown_list_item;
 pub use prerelease::{
     VersionChange, enter_prerelease, exit_prerelease, restore_preserved_changesets,
+    validate_prerelease_entry,
 };
 pub use publish::{PublishExtraArgs, run_publish, tag_published_crate, topo_order};
 pub use release::{

--- a/crates/sampo-core/src/prerelease.rs
+++ b/crates/sampo-core/src/prerelease.rs
@@ -25,16 +25,38 @@ pub fn enter_prerelease(
     label: &str,
 ) -> Result<Vec<VersionChange>> {
     let workspace = discover_workspace(root)?;
-    let targets = resolve_targets(&workspace, packages)?;
-    let prerelease = validate_label(label)?;
-
-    let (changes, new_versions) = plan_enter_updates(&targets, &prerelease)?;
+    let (changes, new_versions) = plan_entry(&workspace, packages, label)?;
     if new_versions.is_empty() {
         return Ok(Vec::new());
     }
 
     apply_version_updates(&workspace, &new_versions)?;
     Ok(changes)
+}
+
+/// Report whether entering `label` would be accepted, without writing anything.
+///
+/// The verdict survives a label switch's rollback, since entering strips any existing
+/// pre-release before applying the label. It is only as fresh as `workspace`:
+/// re-discover after writing manifests.
+pub fn validate_prerelease_entry(
+    workspace: &Workspace,
+    packages: &[String],
+    label: &str,
+) -> Result<()> {
+    plan_entry(workspace, packages, label)?;
+    Ok(())
+}
+
+/// The version changes entering `label` would make, shared so entry and validation agree.
+fn plan_entry(
+    workspace: &Workspace,
+    packages: &[String],
+    label: &str,
+) -> Result<(Vec<VersionChange>, BTreeMap<String, String>)> {
+    let targets = resolve_targets(workspace, packages)?;
+    let prerelease = validate_label(label)?;
+    plan_enter_updates(&targets, &prerelease)
 }
 
 /// Exit pre-release mode for the selected packages, restoring stable versions.
@@ -229,6 +251,14 @@ fn plan_exit_updates(
     Ok((changes, new_versions))
 }
 
+/// `sampo pre` owns the whole run, so adapter failures surface under its own variant.
+fn to_prerelease(err: SampoError) -> SampoError {
+    match err {
+        SampoError::Release(msg) => SampoError::Prerelease(msg),
+        other => other,
+    }
+}
+
 fn apply_version_updates(
     workspace: &Workspace,
     new_versions: &BTreeMap<String, String>,
@@ -256,27 +286,23 @@ fn apply_version_updates(
             .map(|(k, v)| (k.clone(), v.clone()))
             .collect();
 
-        let (updated, _deps) = adapter.update_manifest_versions(
-            &manifest_path,
-            &original,
-            new_pkg_version,
-            &filtered_versions,
-        )?;
+        let (updated, _deps) = adapter
+            .update_manifest_versions(
+                &manifest_path,
+                &original,
+                new_pkg_version,
+                &filtered_versions,
+            )
+            .map_err(to_prerelease)?;
 
         if updated != original {
             fs::write(&manifest_path, updated)?;
         }
     }
 
-    PackageAdapter::finalize_workspace_roots(workspace, new_versions).map_err(|err| match err {
-        SampoError::Release(msg) => SampoError::Prerelease(msg),
-        other => other,
-    })?;
+    PackageAdapter::finalize_workspace_roots(workspace, new_versions).map_err(to_prerelease)?;
 
-    regenerate_lockfile(workspace).map_err(|err| match err {
-        SampoError::Release(msg) => SampoError::Prerelease(msg),
-        other => other,
-    })?;
+    regenerate_lockfile(workspace).map_err(to_prerelease)?;
 
     Ok(())
 }
@@ -398,6 +424,31 @@ mod tests {
             }
             other => panic!("unexpected error: {other:?}"),
         }
+    }
+
+    #[test]
+    fn validating_an_entry_answers_without_writing() {
+        let temp = init_workspace();
+        let root = temp.path();
+        let before = fs::read_to_string(root.join("crates/foo/Cargo.toml")).unwrap();
+
+        let workspace = discover_workspace(root).unwrap();
+        let err = validate_prerelease_entry(&workspace, &[String::from("foo")], "123").unwrap_err();
+        match err {
+            SampoError::Prerelease(msg) => {
+                assert!(msg.contains("non-numeric"));
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+
+        validate_prerelease_entry(&workspace, &[String::from("foo")], "alpha")
+            .expect("a valid entry must be accepted");
+
+        assert_eq!(
+            fs::read_to_string(root.join("crates/foo/Cargo.toml")).unwrap(),
+            before,
+            "validation must never write a manifest"
+        );
     }
 
     #[test]

--- a/crates/sampo-core/src/publish.rs
+++ b/crates/sampo-core/src/publish.rs
@@ -603,9 +603,16 @@ mod tests {
     use std::{
         ffi::OsString,
         fs,
+        io::{Read, Write},
+        net::{TcpListener, TcpStream},
         path::PathBuf,
         process::Command,
-        sync::{Mutex, MutexGuard, OnceLock},
+        sync::{
+            Arc, Mutex, MutexGuard, OnceLock, PoisonError,
+            atomic::{AtomicBool, Ordering},
+        },
+        thread,
+        time::Duration,
     };
 
     /// Initialise a git repo with a first commit so HEAD exists.
@@ -817,7 +824,9 @@ mod tests {
 
     impl ScopedEnv {
         fn set(overrides: &[(&'static str, OsString)]) -> Self {
-            let lock = env_lock().lock().unwrap();
+            // Recover from a poisoned mutex: the env state it protects is restored by
+            // Drop regardless, so one panicking test must not cascade into the rest.
+            let lock = env_lock().lock().unwrap_or_else(PoisonError::into_inner);
             let mut original = Vec::with_capacity(overrides.len());
             for (key, _) in overrides {
                 original.push((*key, std::env::var_os(key)));
@@ -886,14 +895,87 @@ fn main() {
 }
 "#;
 
+    /// Local stand-in for the crates.io existence check: answers every request with a
+    /// fixed status, keeping publish tests off the rate-limited real API.
+    struct FakeCratesIo {
+        base_url: String,
+        addr: std::net::SocketAddr,
+        stop: Arc<AtomicBool>,
+        handle: Option<thread::JoinHandle<()>>,
+    }
+
+    impl FakeCratesIo {
+        fn serve(status_line: &'static str) -> Self {
+            let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+            let addr = listener.local_addr().unwrap();
+            let stop = Arc::new(AtomicBool::new(false));
+            let thread_stop = Arc::clone(&stop);
+            let handle = thread::spawn(move || {
+                for stream in listener.incoming() {
+                    if thread_stop.load(Ordering::SeqCst) {
+                        break;
+                    }
+                    let Ok(mut stream) = stream else { continue };
+                    // Drain the request headers before answering: responding with
+                    // inbound data still pending can RST the connection before the
+                    // client reads the status.
+                    let _ = stream.set_read_timeout(Some(Duration::from_secs(5)));
+                    let mut request = Vec::new();
+                    let mut buffer = [0u8; 1024];
+                    while !request.windows(4).any(|w| w == b"\r\n\r\n") && request.len() < 8192 {
+                        match stream.read(&mut buffer) {
+                            Ok(0) | Err(_) => break,
+                            Ok(n) => request.extend_from_slice(&buffer[..n]),
+                        }
+                    }
+                    let response = format!(
+                        "HTTP/1.1 {status_line}\r\ncontent-length: 0\r\nconnection: close\r\n\r\n"
+                    );
+                    let _ = stream.write_all(response.as_bytes());
+                }
+            });
+            Self {
+                base_url: format!("http://{addr}"),
+                addr,
+                stop,
+                handle: Some(handle),
+            }
+        }
+    }
+
+    impl Drop for FakeCratesIo {
+        fn drop(&mut self) {
+            self.stop.store(true, Ordering::SeqCst);
+            // Unblock the accept loop so the thread can observe the stop flag.
+            let _ = TcpStream::connect(self.addr);
+            if let Some(handle) = self.handle.take() {
+                let _ = handle.join();
+            }
+        }
+    }
+
     struct FakeCargo {
         log_path: PathBuf,
         _env: ScopedEnv,
         _temp: tempfile::TempDir,
+        // The override guard drops before the server it points at.
+        _crates_io_base: crate::adapters::cargo::CratesIoApiBaseOverrideGuard,
+        _crates_io: FakeCratesIo,
     }
 
     impl FakeCargo {
+        /// Installs the stub cargo binary plus a local crates.io stand-in reporting
+        /// every version as unpublished (the common case).
         fn install(fail_dry_run: bool, fail_actual: bool, version: &str) -> Self {
+            Self::install_with_registry(fail_dry_run, fail_actual, version, false)
+        }
+
+        fn install_with_registry(
+            fail_dry_run: bool,
+            fail_actual: bool,
+            version: &str,
+            already_published: bool,
+        ) -> Self {
             let temp_dir = tempfile::tempdir().unwrap();
             let bin_dir = temp_dir.path().join("bin");
             fs::create_dir_all(&bin_dir).unwrap();
@@ -932,6 +1014,14 @@ fn main() {
                 path_override.push(&existing);
             }
 
+            let crates_io = FakeCratesIo::serve(if already_published {
+                "200 OK"
+            } else {
+                "404 Not Found"
+            });
+            let crates_io_base =
+                crate::adapters::cargo::override_crates_io_api_base_for_tests(&crates_io.base_url);
+
             let overrides = vec![
                 ("PATH", path_override),
                 ("SAMPO_FAKE_CARGO_LOG", log_path.clone().into_os_string()),
@@ -952,6 +1042,8 @@ fn main() {
                 log_path,
                 _env: env_guard,
                 _temp: temp_dir,
+                _crates_io_base: crates_io_base,
+                _crates_io: crates_io,
             }
         }
 
@@ -2198,41 +2290,36 @@ edition = "2021"
     /// Regression test: when all packages already exist on the registry,
     /// preflight dry-run validation should be skipped entirely.
     ///
-    /// This test uses `serde` version `1.0.0` which is known to exist on crates.io.
+    /// The local [`FakeCratesIo`] registry reports every version as published.
     /// The test verifies that:
     /// 1. `version_exists()` returns true for the package
     /// 2. No cargo publish commands are executed (FakeCargo log is empty)
     /// 3. The publish function completes successfully
-    ///
-    /// NOTE: This test requires network access to query crates.io.
     #[test]
     fn skips_preflight_when_all_packages_already_published() {
-        // Use a well-known crate that definitely exists on crates.io
         let temp_dir = tempfile::tempdir().unwrap();
         let root = temp_dir.path().to_path_buf();
 
         // Create .sampo/ directory
         fs::create_dir_all(root.join(".sampo")).unwrap();
 
-        // Create workspace structure with a crate name matching an existing crates.io package
         fs::write(
             root.join("Cargo.toml"),
             "[workspace]\nmembers=[\"crates/*\"]\n",
         )
         .unwrap();
 
-        let crate_dir = root.join("crates").join("serde");
+        let crate_dir = root.join("crates").join("published-crate");
         fs::create_dir_all(crate_dir.join("src")).unwrap();
         fs::write(
             crate_dir.join("Cargo.toml"),
-            // Use a version that definitely exists on crates.io
-            "[package]\nname=\"serde\"\nversion=\"1.0.0\"\nedition=\"2021\"\n",
+            "[package]\nname=\"published-crate\"\nversion=\"1.0.0\"\nedition=\"2021\"\n",
         )
         .unwrap();
         fs::write(crate_dir.join("src/lib.rs"), "// test").unwrap();
 
-        // Install FakeCargo to intercept publish commands
-        let fake_cargo = FakeCargo::install(false, false, "1.91.0");
+        // `true`: the local registry reports the version as already published.
+        let fake_cargo = FakeCargo::install_with_registry(false, false, "1.91.0", true);
 
         // Run publish (not dry-run)
         let _branch_guard = override_current_branch_for_tests("main");

--- a/crates/sampo-core/src/release.rs
+++ b/crates/sampo-core/src/release.rs
@@ -825,11 +825,28 @@ fn compute_plan_state(
         return Ok(PlanOutcome::NoApplicablePackages);
     }
 
-    let dependents = build_dependency_graph(workspace, config);
-    apply_dependency_cascade(&mut bump_by_pkg, &dependents, config, workspace)?;
-    apply_linked_dependencies(&mut bump_by_pkg, config, workspace)?;
+    // Snapshot the changeset targets before the cascade widens the map, so a failure can
+    // tell the user whether they named the package or the release pulled it in.
+    let direct_targets: BTreeSet<String> = bump_by_pkg.keys().cloned().collect();
 
-    let releases = prepare_release_plan(&bump_by_pkg, workspace, preserved_targets, stabilize)?;
+    let dependents = build_dependency_graph(workspace, config);
+    // A linked raise can outrun the coupling the cascade just settled, so re-settle until
+    // linked has nothing left to raise. Bumps only ever rise through three levels over a
+    // finite set of packages, so this converges; with no `packages.linked` it runs once.
+    loop {
+        apply_dependency_cascade(&mut bump_by_pkg, &dependents, config, workspace)?;
+        if !apply_linked_dependencies(&mut bump_by_pkg, config, workspace)? {
+            break;
+        }
+    }
+
+    let releases = prepare_release_plan(
+        &bump_by_pkg,
+        workspace,
+        preserved_targets,
+        stabilize,
+        &direct_targets,
+    )?;
     if releases.is_empty() {
         return Ok(PlanOutcome::NoMatchingCrates);
     }
@@ -1550,12 +1567,15 @@ fn apply_dependency_cascade(
                     .entry(dep_name.clone())
                     .or_insert(dependent_bump);
                 // If already present, keep the higher bump
-                if *entry < dependent_bump {
+                let raised = *entry < dependent_bump;
+                if raised {
                     *entry = dependent_bump;
                 }
-                if !seen.contains(dep_name) {
+                // Re-queue on a raise, not only on first sight: a package popped before
+                // its bump grew would otherwise never carry the higher level onward.
+                let first_sight = seen.insert(dep_name.clone());
+                if raised || first_sight {
                     queue.push(dep_name.clone());
-                    seen.insert(dep_name.clone());
                 }
             }
         }
@@ -1584,12 +1604,13 @@ fn apply_dependency_cascade(
                     .entry(group_member.clone())
                     .or_insert(changed_bump);
                 // If already present, keep the higher bump
-                if *entry < changed_bump {
+                let raised = *entry < changed_bump;
+                if raised {
                     *entry = changed_bump;
                 }
-                if !seen.contains(group_member) {
+                let first_sight = seen.insert(group_member.clone());
+                if raised || first_sight {
                     queue.push(group_member.clone());
-                    seen.insert(group_member.clone());
                 }
             }
         }
@@ -1598,13 +1619,17 @@ fn apply_dependency_cascade(
     Ok(())
 }
 
-/// Apply linked dependencies logic: highest bump level to affected packages only
+/// Apply linked dependencies logic: highest bump level to affected packages only.
+///
+/// Returns whether any bump was raised, so the caller can re-settle the dependency
+/// cascade and `packages.fixed` groups a raise may have outrun.
 fn apply_linked_dependencies(
     bump_by_pkg: &mut BTreeMap<String, Bump>,
     cfg: &Config,
     ws: &Workspace,
-) -> Result<()> {
+) -> Result<bool> {
     let resolved_groups = resolve_config_groups(ws, &cfg.linked_dependencies, "packages.linked")?;
+    let mut raised = false;
 
     for group in &resolved_groups {
         // Check if any package in this group has been bumped
@@ -1634,13 +1659,34 @@ fn apply_linked_dependencies(
                         .unwrap_or(Bump::Patch);
                     if highest_bump > current_bump {
                         bump_by_pkg.insert(group_member.clone(), highest_bump);
+                        raised = true;
                     }
                 }
             }
         }
     }
 
-    Ok(())
+    Ok(raised)
+}
+
+/// A version Sampo cannot parse or bump stops the run: planning it as a no-op would
+/// consume the changeset and log an entry under a version that never moved. Packages
+/// the user never named get extra context explaining how they joined the plan.
+fn version_plan_error(
+    identifier: &str,
+    old: &str,
+    reason: &str,
+    direct_targets: &BTreeSet<String>,
+) -> SampoError {
+    let mut message = format!("Cannot release '{identifier}' ({old}): {reason}");
+    if !direct_targets.contains(identifier) {
+        message.push_str(
+            ". It joined this release because it depends on a package being released or \
+             shares a version group with it",
+        );
+    }
+    message.push_str("; fix its version, or exclude it with packages.ignore");
+    SampoError::Release(message)
 }
 
 /// Prepare the release plan by matching bumps to workspace members
@@ -1649,6 +1695,7 @@ fn prepare_release_plan(
     ws: &Workspace,
     preserved_targets: &BTreeSet<String>,
     stabilize: bool,
+    direct_targets: &BTreeSet<String>,
 ) -> Result<ReleasePlan> {
     // Map package identifier -> PackageInfo for quick lookup
     let mut by_id: BTreeMap<String, &PackageInfo> = BTreeMap::new();
@@ -1665,19 +1712,16 @@ fn prepare_release_plan(
                 info.version.clone()
             };
 
-            let newv = match parse_version_string(&old) {
-                Ok(parsed) => {
-                    if stabilize && !parsed.pre.is_empty() {
-                        stabilize_version_from_parsed(&parsed, *bump)
-                            .unwrap_or_else(|_| old.clone())
-                    } else if should_bump_prerelease_base(&parsed, identifier, preserved_targets) {
-                        bump_prerelease_entry(&parsed, *bump).unwrap_or_else(|_| old.clone())
-                    } else {
-                        bump_version_from_parsed(&parsed, *bump).unwrap_or_else(|_| old.clone())
-                    }
-                }
-                Err(_) => old.clone(),
-            };
+            let parsed = parse_version_string(&old)
+                .map_err(|err| version_plan_error(identifier, &old, &err, direct_targets))?;
+            let newv = if stabilize && !parsed.pre.is_empty() {
+                stabilize_version_from_parsed(&parsed, *bump)
+            } else if should_bump_prerelease_base(&parsed, identifier, preserved_targets) {
+                bump_prerelease_entry(&parsed, *bump)
+            } else {
+                bump_version_from_parsed(&parsed, *bump)
+            }
+            .map_err(|err| version_plan_error(identifier, &old, &err, direct_targets))?;
 
             releases.push((identifier.clone(), old, newv));
         }

--- a/crates/sampo-core/src/release_tests.rs
+++ b/crates/sampo-core/src/release_tests.rs
@@ -5,7 +5,7 @@ mod tests {
         collections::{BTreeMap, BTreeSet},
         fs,
         path::PathBuf,
-        sync::{Mutex, MutexGuard, OnceLock},
+        sync::{Mutex, MutexGuard, OnceLock, PoisonError},
     };
 
     use crate::*;
@@ -31,7 +31,9 @@ mod tests {
 
     impl EnvVarGuard {
         fn set(key: &'static str, value: &str) -> Self {
-            let lock = env_lock().lock().unwrap();
+            // Recover from a poisoned mutex: the env state it protects is restored by
+            // Drop regardless, so one panicking test must not cascade into the rest.
+            let lock = env_lock().lock().unwrap_or_else(PoisonError::into_inner);
             let original = std::env::var(key).ok();
             unsafe {
                 std::env::set_var(key, value);
@@ -62,7 +64,7 @@ mod tests {
             let root = temp_dir.path().to_path_buf();
 
             {
-                let _lock = env_lock().lock().unwrap();
+                let _lock = env_lock().lock().unwrap_or_else(PoisonError::into_inner);
                 unsafe {
                     std::env::set_var("SAMPO_RELEASE_BRANCH", "main");
                 }
@@ -1767,7 +1769,7 @@ tempfile = "3.0"
         let root = temp_dir.path().to_path_buf();
 
         {
-            let _lock = env_lock().lock().unwrap();
+            let _lock = env_lock().lock().unwrap_or_else(PoisonError::into_inner);
             unsafe {
                 std::env::set_var("SAMPO_RELEASE_BRANCH", "main");
             }
@@ -2013,7 +2015,7 @@ bar = { version = "1.0.0", path = "crates/bar" }
         message: &str,
     ) {
         {
-            let _lock = env_lock().lock().unwrap();
+            let _lock = env_lock().lock().unwrap_or_else(PoisonError::into_inner);
             unsafe {
                 std::env::set_var("SAMPO_RELEASE_BRANCH", "main");
             }
@@ -2254,5 +2256,178 @@ end
             "ignored package `b` must not appear in released packages, got {:?}",
             released
         );
+    }
+
+    fn set_release_branch_main() {
+        let _lock = env_lock().lock().unwrap_or_else(PoisonError::into_inner);
+        unsafe {
+            std::env::set_var("SAMPO_RELEASE_BRANCH", "main");
+        }
+    }
+
+    #[test]
+    fn unbumpable_prerelease_fails_and_names_its_version() {
+        // `npm version prerelease` produces this shape: the base bump outruns the implied
+        // one, leaving no non-numeric identifier to hang the counter on.
+        let mut workspace = TestWorkspace::new();
+        workspace.add_crate("demo", "1.2.4-0");
+        workspace.add_changeset(&["demo"], Bump::Minor, "feat: a change");
+
+        let err = workspace
+            .run_release(false)
+            .expect_err("an unbumpable pre-release must fail the run");
+        match err {
+            crate::errors::SampoError::Release(message) => {
+                assert!(
+                    message.contains("cargo/demo") && message.contains("1.2.4-0"),
+                    "the message must name the package and its version, got: {message}"
+                );
+            }
+            other => panic!("expected Release error, got {other:?}"),
+        }
+
+        workspace.assert_crate_version("demo", "1.2.4-0");
+        let pending = fs::read_dir(workspace.root.join(".sampo/changesets"))
+            .unwrap()
+            .count();
+        assert_eq!(pending, 1, "the changeset must survive a failed release");
+    }
+
+    #[test]
+    fn cascade_pulled_package_explains_why_it_blocks_the_release() {
+        set_release_branch_main();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let root = temp_dir.path();
+        fs::create_dir_all(root.join(".sampo/changesets")).unwrap();
+
+        // Only `app` has a changeset; `lib` is dragged in as a dependent, on a valid
+        // PEP 440 version Sampo cannot bump.
+        fs::write(
+            root.join("pyproject.toml"),
+            "[project]\nname = \"root\"\nversion = \"0.1.0\"\n\n[tool.uv.workspace]\nmembers = [\"app\", \"lib\"]\n",
+        )
+        .unwrap();
+        fs::create_dir_all(root.join("app")).unwrap();
+        fs::write(
+            root.join("app/pyproject.toml"),
+            "[project]\nname = \"app\"\nversion = \"1.0.0\"\n",
+        )
+        .unwrap();
+        fs::create_dir_all(root.join("lib")).unwrap();
+        fs::write(
+            root.join("lib/pyproject.toml"),
+            "[project]\nname = \"lib\"\nversion = \"1.0.0.post1\"\ndependencies = [\"app>=1.0\"]\n",
+        )
+        .unwrap();
+
+        fs::write(
+            root.join(".sampo/changesets/c.md"),
+            "---\npypi/app: minor\n---\n\nfeat: a change\n",
+        )
+        .unwrap();
+
+        let err = run_release(root, false).expect_err("an unbumpable dependent must fail the run");
+        match err {
+            crate::errors::SampoError::Release(message) => {
+                assert!(
+                    message.contains("pypi/lib") && message.contains("joined this release"),
+                    "the message must explain why an untouched package blocks the run, got: {message}"
+                );
+            }
+            other => panic!("expected Release error, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn unparseable_version_fails_for_any_ecosystem() {
+        set_release_branch_main();
+        let temp_dir = tempfile::tempdir().unwrap();
+        let root = temp_dir.path();
+        fs::create_dir_all(root.join(".sampo/changesets")).unwrap();
+
+        // The guard lives in shared planning code, not in an adapter.
+        let manifest = "[project]\nname = \"demo\"\nversion = \"1.0.0.post1\"\n";
+        fs::write(root.join("pyproject.toml"), manifest).unwrap();
+
+        let changeset = root.join(".sampo/changesets/c.md");
+        fs::write(&changeset, "---\npypi/demo: minor\n---\n\nfeat: a change\n").unwrap();
+
+        let err = run_release(root, false).expect_err("an unbumpable version must fail the run");
+        match err {
+            crate::errors::SampoError::Release(message) => {
+                assert!(
+                    message.contains("pypi/demo") && message.contains("1.0.0.post1"),
+                    "expected the package and its version to be named, got: {message}"
+                );
+                assert!(
+                    !message.contains("joined this release"),
+                    "a directly-named package must not be reported as pulled in, got: {message}"
+                );
+                assert!(
+                    message.contains("fix its version, or exclude it with packages.ignore"),
+                    "the remedy must not depend on how the package entered the plan, got: {message}"
+                );
+            }
+            other => panic!("expected Release error, got {other:?}"),
+        }
+
+        assert!(
+            changeset.exists(),
+            "the changeset must survive a failed release"
+        );
+        assert_eq!(
+            fs::read_to_string(root.join("pyproject.toml")).unwrap(),
+            manifest
+        );
+    }
+
+    #[test]
+    fn fixed_group_lands_on_one_bump_level_when_a_member_is_raised_late() {
+        // `m` is only reached through its fixed group, and `z`'s major arrives after the
+        // group was already settled at patch. Without re-propagation the two split, and
+        // a fixed group silently released at inconsistent versions.
+        set_release_branch_main();
+        let mut workspace = TestWorkspace::new();
+        workspace.add_crate("dep", "1.0.0");
+        workspace.add_crate("m", "1.0.0");
+        workspace.add_crate("z", "1.0.0");
+        workspace.add_dependency("z", "dep", "1.0.0");
+        workspace.set_config("[packages]\nfixed = [[\"cargo/m\", \"cargo/z\"]]\n");
+        workspace.add_changeset(&["m"], Bump::Patch, "fix: m");
+        workspace.add_changeset(&["dep"], Bump::Major, "feat: dep");
+
+        workspace
+            .run_release(false)
+            .expect("release should succeed");
+
+        workspace.assert_crate_version("dep", "2.0.0");
+        workspace.assert_crate_version("z", "2.0.0");
+        workspace.assert_crate_version("m", "2.0.0");
+    }
+
+    #[test]
+    fn fixed_group_follows_a_linked_raise() {
+        // The linked raise on `x` lands after the cascade settled `d`/`e` at patch, so the
+        // fixed group has to be re-settled or it releases below its dependency.
+        set_release_branch_main();
+        let mut workspace = TestWorkspace::new();
+        workspace.add_crate("x", "1.0.0");
+        workspace.add_crate("y", "1.0.0");
+        workspace.add_crate("d", "1.0.0");
+        workspace.add_crate("e", "1.0.0");
+        workspace.add_dependency("d", "x", "1.0.0");
+        workspace.set_config(
+            "[packages]\nlinked = [[\"cargo/x\", \"cargo/y\"]]\nfixed = [[\"cargo/d\", \"cargo/e\"]]\n",
+        );
+        workspace.add_changeset(&["x"], Bump::Patch, "fix: x");
+        workspace.add_changeset(&["y"], Bump::Major, "feat: y");
+
+        workspace
+            .run_release(false)
+            .expect("release should succeed");
+
+        workspace.assert_crate_version("x", "2.0.0");
+        workspace.assert_crate_version("d", "2.0.0");
+        workspace.assert_crate_version("e", "2.0.0");
     }
 }

--- a/crates/sampo/src/prerelease.rs
+++ b/crates/sampo/src/prerelease.rs
@@ -11,6 +11,7 @@ use sampo_core::{
     filters::filter_members,
     restore_preserved_changesets,
     types::{PackageSpecifier, SpecResolution, format_ambiguity_options},
+    validate_prerelease_entry,
 };
 use semver::Version;
 use std::collections::{BTreeSet, HashMap};
@@ -108,6 +109,10 @@ fn run_enter(args: &PreEnterArgs) -> Result<bool> {
     let label = resolve_label(args.label.as_deref())?;
 
     let mut any_changes = false;
+
+    // Validate before the label switch: a refused run would otherwise exit pre-release
+    // mode with its preserved changesets already moved back.
+    validate_prerelease_entry(&workspace, &canonical, &label)?;
 
     let packages_to_reset = packages_requiring_label_switch(&workspace, &canonical, &label)?;
     if !packages_to_reset.is_empty() {


### PR DESCRIPTION
## What has changed?

Extracted from #296, which rebases on top. `sampo release` now refuses a package whose version it cannot parse or bump (a PEP 440 `1.0.0.post1`, a Composer `v1.2.3`) instead of planning a do-nothing release that consumed the changeset and wrote a changelog entry under the unchanged version; the error names the package and the remedy, and `sampo pre enter` runs the same validation before its label switch, so a refused entry no longer drops the workspace out of pre-release mode. Since previously-green runs can now fail, the changeset carries a breaking-change prefix at minor, matching #181.

The dependency cascade also re-queues a package whose bump is raised after first sight, and re-settles `packages.fixed` groups after a `packages.linked` raise — a fixed group could previously release its members at different bump levels, silently. Incidentally makes the publish suite hermetic: a local stand-in replaces the live crates.io existence check (which rate-limits busy IPs), and the test env mutexes recover from poisoning.

## How is it tested?

Generic tests ported from #296: two pure-Cargo convergence tests (a fixed-group member raised late, a fixed group following a linked raise) and three refusal tests on Cargo and PyPI fixtures, asserting the error names the package, nothing is written, the changeset survives, and the remedy shows whether the package was named directly or pulled in; plus a new dry-run test for `validate_prerelease_entry`. The previously network-dependent publish test now runs against the local registry stub. `cargo test --all`, `clippy`, and `fmt` are clean.

## How is it documented?

Two changesets: the refusal at minor with the breaking-change prefix (including `sampo-github-action`), the convergence fix at patch. No README change — both fixes make already-documented behaviour hold.