### PR TITLE
fix(core/npm): yarn dry-run publish

### DIFF
--- a/.sampo/changesets/sturdy-yarn-ilmarinen.md
+++ b/.sampo/changesets/sturdy-yarn-ilmarinen.md
@@ -1,0 +1,7 @@
+---
+cargo/sampo: patch
+cargo/sampo-core: patch
+cargo/sampo-github-action: patch
+---
+
+In JavaScript/TypeScript (npm) projects, fixed a dry-run publish that published for real on Yarn Classic, and publishing on Yarn Berry, which never reached the registry. Where yarn cannot simulate a publish, the dry run is now skipped with a warning.

--- a/crates/sampo-core/src/adapters.rs
+++ b/crates/sampo-core/src/adapters.rs
@@ -13,6 +13,13 @@ use std::collections::BTreeMap;
 use std::path::Path;
 use std::process::Command;
 
+/// Whether the publish spawned a command at all.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PublishOutcome {
+    Ran,
+    DryRunSkipped,
+}
+
 /// Package ecosystem adapter (Cargo, npm, etc.).
 #[derive(Debug, Clone, Copy)]
 pub enum PackageAdapter {
@@ -111,27 +118,37 @@ impl PackageAdapter {
         manifest_path: &Path,
         dry_run: bool,
         extra_args: &[String],
-    ) -> Result<()> {
+    ) -> Result<PublishOutcome> {
         match self {
-            Self::Cargo => cargo::CargoAdapter.publish(manifest_path, dry_run, extra_args),
+            Self::Cargo => cargo::CargoAdapter
+                .publish(manifest_path, dry_run, extra_args)
+                .map(|()| PublishOutcome::Ran),
             Self::Npm => npm::NpmAdapter.publish(manifest_path, dry_run, extra_args),
-            Self::Hex => hex::HexAdapter.publish(manifest_path, dry_run, extra_args),
-            Self::PyPI => pypi::PyPIAdapter.publish(manifest_path, dry_run, extra_args),
-            Self::Packagist => {
-                packagist::PackagistAdapter.publish(manifest_path, dry_run, extra_args)
-            }
-            Self::Maven => maven::MavenAdapter.publish(manifest_path, dry_run, extra_args),
+            Self::Hex => hex::HexAdapter
+                .publish(manifest_path, dry_run, extra_args)
+                .map(|()| PublishOutcome::Ran),
+            Self::PyPI => pypi::PyPIAdapter
+                .publish(manifest_path, dry_run, extra_args)
+                .map(|()| PublishOutcome::Ran),
+            Self::Packagist => packagist::PackagistAdapter
+                .publish(manifest_path, dry_run, extra_args)
+                .map(|()| PublishOutcome::Ran),
+            Self::Maven => maven::MavenAdapter
+                .publish(manifest_path, dry_run, extra_args)
+                .map(|()| PublishOutcome::Ran),
         }
     }
 
     /// Execute dry-run publish validation for the provided packages.
     /// Adapters can choose the most appropriate strategy (workspace-level or per-package).
+    /// Returns the packages it could not validate, as kind-qualified
+    /// [`PackageInfo::display_name`] values.
     pub fn publish_dry_run(
         &self,
         workspace_root: &Path,
         packages: &[(&PackageInfo, &Path)],
         extra_args: &[String],
-    ) -> Result<()> {
+    ) -> Result<Vec<String>> {
         match self {
             Self::Cargo => cargo::publish_dry_run(workspace_root, packages, extra_args),
             Self::Npm => npm::publish_dry_run(packages, extra_args),

--- a/crates/sampo-core/src/adapters/cargo.rs
+++ b/crates/sampo-core/src/adapters/cargo.rs
@@ -230,9 +230,9 @@ pub(super) fn publish_dry_run(
     workspace_root: &Path,
     packages: &[(&PackageInfo, &Path)],
     extra_args: &[String],
-) -> Result<()> {
+) -> Result<Vec<String>> {
     if packages.is_empty() {
-        return Ok(());
+        return Ok(Vec::new());
     }
 
     let has_dependent_packages = packages
@@ -250,6 +250,7 @@ pub(super) fn publish_dry_run(
                     .map(|(package, _)| package.name.as_str())
                     .collect();
                 return workspace_publish_dry_run(workspace_root, &package_names, extra_args)
+                    .map(|()| Vec::new())
                     .map_err(|err| match err {
                         SampoError::Publish(message) => SampoError::Publish(format!(
                             "Cargo workspace dry-run failed: {}",
@@ -284,19 +285,22 @@ pub(super) fn publish_dry_run(
         }
     }
 
+    let mut skipped = Vec::new();
+
     for (package, manifest) in packages {
         if skip_dependent_packages && !package.internal_deps.is_empty() {
             println!(
                 "  - Skipping dry-run for {} (requires workspace-aware Cargo to validate dependencies)",
                 package.display_name(true)
             );
+            skipped.push(package.display_name(true));
             continue;
         }
 
         run_cargo_dry_run(package, manifest, extra_args)?;
     }
 
-    Ok(())
+    Ok(skipped)
 }
 
 fn run_cargo_dry_run(

--- a/crates/sampo-core/src/adapters/hex.rs
+++ b/crates/sampo-core/src/adapters/hex.rs
@@ -490,7 +490,7 @@ fn satisfies_pessimistic(version_str: &str, version: (u64, u64, u64)) -> Option<
 pub(super) fn publish_dry_run(
     packages: &[(&PackageInfo, &Path)],
     extra_args: &[String],
-) -> Result<()> {
+) -> Result<Vec<String>> {
     for (package, manifest) in packages {
         HexAdapter
             .publish(manifest, true, extra_args)
@@ -504,7 +504,7 @@ pub(super) fn publish_dry_run(
             })?;
     }
 
-    Ok(())
+    Ok(Vec::new())
 }
 
 fn enforce_hex_rate_limit() {

--- a/crates/sampo-core/src/adapters/maven.rs
+++ b/crates/sampo-core/src/adapters/maven.rs
@@ -177,7 +177,7 @@ fn enforce_maven_rate_limit() {
 pub(super) fn publish_dry_run(
     packages: &[(&PackageInfo, &Path)],
     extra_args: &[String],
-) -> Result<()> {
+) -> Result<Vec<String>> {
     for (package, manifest) in packages {
         MavenAdapter
             .publish(manifest, true, extra_args)
@@ -191,7 +191,7 @@ pub(super) fn publish_dry_run(
             })?;
     }
 
-    Ok(())
+    Ok(Vec::new())
 }
 
 /// Update a Maven POM with a new package version and refreshed dependency references.

--- a/crates/sampo-core/src/adapters/npm.rs
+++ b/crates/sampo-core/src/adapters/npm.rs
@@ -1,4 +1,4 @@
-use crate::adapters::{format_command_display, has_flag, require_on_path};
+use crate::adapters::{PublishOutcome, format_command_display, has_flag, require_on_path};
 use crate::errors::{Result, SampoError, WorkspaceError};
 use crate::process::command;
 use crate::types::{PackageInfo, PackageKind};
@@ -93,7 +93,7 @@ impl NpmAdapter {
         manifest_path: &Path,
         dry_run: bool,
         extra_args: &[String],
-    ) -> Result<()> {
+    ) -> Result<PublishOutcome> {
         let manifest_dir = manifest_path.parent().ok_or_else(|| {
             SampoError::Publish(format!(
                 "Manifest {} does not have a parent directory",
@@ -131,7 +131,7 @@ impl NpmAdapter {
                 "Warning: skipping dry-run publish for '{}': {gap}. This package was not validated.",
                 info.name
             );
-            return Ok(());
+            return Ok(PublishOutcome::DryRunSkipped);
         }
 
         let mut cmd = command(manager_name);
@@ -169,7 +169,7 @@ impl NpmAdapter {
             )));
         }
 
-        Ok(())
+        Ok(PublishOutcome::Ran)
     }
 
     pub(super) fn regenerate_lockfile(&self, workspace_root: &Path) -> Result<()> {
@@ -617,9 +617,11 @@ fn is_wildcard(s: &str) -> bool {
 pub(super) fn publish_dry_run(
     packages: &[(&PackageInfo, &Path)],
     extra_args: &[String],
-) -> Result<()> {
+) -> Result<Vec<String>> {
+    let mut skipped = Vec::new();
+
     for (package, manifest) in packages {
-        NpmAdapter
+        let outcome = NpmAdapter
             .publish(manifest, true, extra_args)
             .map_err(|err| match err {
                 SampoError::Publish(message) => SampoError::Publish(format!(
@@ -629,9 +631,13 @@ pub(super) fn publish_dry_run(
                 )),
                 other => other,
             })?;
+
+        if outcome == PublishOutcome::DryRunSkipped {
+            skipped.push(package.display_name(true));
+        }
     }
 
-    Ok(())
+    Ok(skipped)
 }
 
 /// A passthrough `--dry-run=false` must never talk a requested dry run into a real publish.

--- a/crates/sampo-core/src/adapters/npm.rs
+++ b/crates/sampo-core/src/adapters/npm.rs
@@ -110,6 +110,8 @@ impl NpmAdapter {
             )));
         }
 
+        let dry_run = wants_dry_run(dry_run, extra_args);
+
         let manager = detect_package_manager(manifest_dir, &info);
         let manager_name = match manager {
             PackageManager::Npm => "npm",
@@ -117,37 +119,29 @@ impl NpmAdapter {
             PackageManager::Yarn => "yarn",
             PackageManager::Bun => "bun",
         };
+
+        let yarn = match manager {
+            PackageManager::Yarn => Some(detect_yarn_publish(manifest_dir)?),
+            _ => None,
+        };
+
+        // Skipping loses validation; running the command anyway would publish for real.
+        if dry_run && let Some(gap) = yarn.as_ref().and_then(YarnPublish::dry_run_gap) {
+            eprintln!(
+                "Warning: skipping dry-run publish for '{}': {gap}. This package was not validated.",
+                info.name
+            );
+            return Ok(());
+        }
+
         let mut cmd = command(manager_name);
-        cmd.arg("publish");
+        cmd.args(publish_command_args(
+            yarn.as_ref(),
+            dry_run,
+            &info,
+            extra_args,
+        ));
         cmd.current_dir(manifest_dir);
-
-        if dry_run && !has_flag(extra_args, "--dry-run") {
-            cmd.arg("--dry-run");
-        }
-
-        if let Some(registry) = info.publish_config.registry.as_deref()
-            && !has_flag(extra_args, "--registry")
-        {
-            cmd.arg("--registry").arg(registry);
-        }
-
-        if !has_flag(extra_args, "--access") {
-            if let Some(access) = info.publish_config.access.as_deref() {
-                cmd.arg("--access").arg(access);
-            } else if info.name.starts_with('@') {
-                cmd.arg("--access").arg("public");
-            }
-        }
-
-        if let Some(tag) = info.publish_config.tag.as_deref()
-            && !has_flag(extra_args, "--tag")
-        {
-            cmd.arg("--tag").arg(tag);
-        }
-
-        if !extra_args.is_empty() {
-            cmd.args(extra_args);
-        }
 
         println!("Running: {}", format_command_display(&cmd));
 
@@ -162,9 +156,13 @@ impl NpmAdapter {
             }
         })?;
         if !status.success() {
+            let attempted = match yarn {
+                Some(YarnPublish::Berry { .. }) => "yarn npm publish".to_string(),
+                _ => format!("{manager_name} publish"),
+            };
             return Err(SampoError::Publish(format!(
-                "{} publish failed for {} (package '{}') with status {}",
-                manager_name,
+                "{} failed for {} (package '{}') with status {}",
+                attempted,
                 manifest_path.display(),
                 info.name,
                 status
@@ -636,6 +634,144 @@ pub(super) fn publish_dry_run(
     Ok(())
 }
 
+/// A passthrough `--dry-run=false` must never talk a requested dry run into a real publish.
+fn wants_dry_run(dry_run: bool, extra_args: &[String]) -> bool {
+    dry_run
+        || extra_args
+            .iter()
+            .any(|arg| match arg.strip_prefix("--dry-run") {
+                Some("") => true,
+                Some(rest) => {
+                    matches!(rest.strip_prefix('='), Some(value) if !matches!(value, "false" | "0"))
+                }
+                None => false,
+            })
+}
+
+fn publish_command_args(
+    yarn: Option<&YarnPublish>,
+    dry_run: bool,
+    info: &NpmManifestInfo,
+    extra_args: &[String],
+) -> Vec<String> {
+    let mut args: Vec<String> = Vec::new();
+
+    // A bare `yarn publish` on Berry falls through to `yarn run publish`, running a user script.
+    if matches!(yarn, Some(YarnPublish::Berry { .. })) {
+        args.push("npm".to_string());
+    }
+    args.push("publish".to_string());
+
+    if dry_run && !has_flag(extra_args, "--dry-run") {
+        args.push("--dry-run".to_string());
+    }
+
+    // Berry rejects `--registry`, but reads `publishConfig.registry` from the manifest this
+    // value came from, so it still applies.
+    if let Some(registry) = info.publish_config.registry.as_deref()
+        && !matches!(yarn, Some(YarnPublish::Berry { .. }))
+        && !has_flag(extra_args, "--registry")
+    {
+        args.push("--registry".to_string());
+        args.push(registry.to_string());
+    }
+
+    if !has_flag(extra_args, "--access") {
+        if let Some(access) = info.publish_config.access.as_deref() {
+            args.push("--access".to_string());
+            args.push(access.to_string());
+        } else if info.name.starts_with('@') {
+            args.push("--access".to_string());
+            args.push("public".to_string());
+        }
+    }
+
+    if let Some(tag) = info.publish_config.tag.as_deref()
+        && !has_flag(extra_args, "--tag")
+    {
+        args.push("--tag".to_string());
+        args.push(tag.to_string());
+    }
+
+    args.extend_from_slice(extra_args);
+    args
+}
+
+/// `yarn npm publish` gained `--dry-run` in 4.9.3 (yarnpkg/berry#6850).
+const YARN_DRY_RUN_FLOOR: (u32, u32, u32) = (4, 9, 3);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum YarnPublish {
+    /// Yarn 1.x: no dry run, and drops unknown flags instead of rejecting them, so
+    /// `--dry-run` publishes for real.
+    Classic,
+    /// Yarn 2+.
+    Berry { version: String, dry_run: bool },
+}
+
+impl YarnPublish {
+    fn dry_run_gap(&self) -> Option<String> {
+        match self {
+            Self::Classic => Some("Yarn Classic has no dry-run publish".to_string()),
+            Self::Berry {
+                version,
+                dry_run: false,
+            } => Some(format!(
+                "`yarn npm publish` gained --dry-run in 4.9.3, and this is {version}"
+            )),
+            Self::Berry { .. } => None,
+        }
+    }
+}
+
+/// Run from the package directory: Classic re-execs into a project's `yarn-path`, so this
+/// reports the yarn that will really publish rather than the shim on `PATH`.
+fn detect_yarn_publish(dir: &Path) -> Result<YarnPublish> {
+    let output = command("yarn")
+        .arg("--version")
+        .current_dir(dir)
+        .output()
+        .map_err(|err| {
+            if err.kind() == std::io::ErrorKind::NotFound {
+                SampoError::Publish(
+                    "yarn not found in PATH; ensure yarn is installed to publish packages"
+                        .to_string(),
+                )
+            } else {
+                SampoError::Io(err)
+            }
+        })?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let snippet: String = stderr.trim().chars().take(400).collect();
+        return Err(SampoError::Publish(format!(
+            "`yarn --version` failed with status {}: {snippet}",
+            output.status
+        )));
+    }
+
+    let reported = String::from_utf8_lossy(&output.stdout);
+    classify_yarn(&reported).ok_or_else(|| {
+        SampoError::Publish(format!(
+            "cannot read a version from `yarn --version` (got {:?}); Sampo needs it to tell \
+             Yarn Classic from Berry, which publish with different commands",
+            reported.trim()
+        ))
+    })
+}
+
+fn classify_yarn(reported: &str) -> Option<YarnPublish> {
+    let (version, parsed) = parse_bare_version(reported)?;
+    if parsed.0 < 2 {
+        return Some(YarnPublish::Classic);
+    }
+    Some(YarnPublish::Berry {
+        version: version.to_string(),
+        dry_run: parsed >= YARN_DRY_RUN_FLOOR,
+    })
+}
+
 fn parse_manifest_info(manifest_path: &Path, manifest: &JsonValue) -> Result<NpmManifestInfo> {
     let name = manifest
         .get("name")
@@ -1066,16 +1202,22 @@ fn lockfile_regen_command(
     }
 }
 
-/// Anchored on the whole output: bun prints one bare version and nothing else, so a version
-/// read out of anything longer could be a date or a build stamp.
-fn parse_bun_version(reported: &str) -> Option<(&str, (u32, u32))> {
+/// Anchored on the whole output: bun and yarn each print one bare version and nothing else,
+/// so a version read out of anything longer could be a date or a build stamp.
+fn parse_bare_version(reported: &str) -> Option<(&str, (u32, u32, u32))> {
     let token = reported.trim();
     if token.split_whitespace().count() != 1 {
         return None;
     }
-    let mut parts = token.split('.');
+    let mut parts = token.split(['-', '+']).next()?.split('.');
     let major = parts.next()?.parse().ok()?;
     let minor = parts.next()?.parse().ok()?;
+    let patch = parts.next().unwrap_or("0").parse().ok()?;
+    Some((token, (major, minor, patch)))
+}
+
+fn parse_bun_version(reported: &str) -> Option<(&str, (u32, u32))> {
+    let (token, (major, minor, _)) = parse_bare_version(reported)?;
     Some((token, (major, minor)))
 }
 

--- a/crates/sampo-core/src/adapters/npm/npm_tests.rs
+++ b/crates/sampo-core/src/adapters/npm/npm_tests.rs
@@ -1019,3 +1019,209 @@ fn detect_workspace_package_manager_fails_when_no_indicators() {
     let err_msg = result.unwrap_err().to_string();
     assert!(err_msg.contains("cannot detect package manager"));
 }
+
+fn manifest_info(name: &str) -> NpmManifestInfo {
+    NpmManifestInfo {
+        name: name.to_string(),
+        version: Some("1.0.0".to_string()),
+        private: false,
+        package_manager: None,
+        publish_config: NpmPublishConfig::default(),
+    }
+}
+
+#[test]
+fn parse_bare_version_keeps_the_patch_and_trims_prereleases() {
+    for (reported, expected) in [
+        ("4.18.0\n", Some(("4.18.0", (4, 18, 0)))),
+        ("4.9.3-rc.1", Some(("4.9.3-rc.1", (4, 9, 3)))),
+        ("1.2.0+build.5", Some(("1.2.0+build.5", (1, 2, 0)))),
+        ("1.22", Some(("1.22", (1, 22, 0)))),
+        ("", None),
+        ("1", None),
+        ("yarn 4.18.0", None),
+    ] {
+        assert_eq!(
+            super::parse_bare_version(reported),
+            expected,
+            "{reported:?}"
+        );
+    }
+}
+
+#[test]
+fn classify_yarn_splits_classic_from_berry_and_finds_the_dry_run_floor() {
+    let berry = |version: &str, dry_run: bool| {
+        Some(YarnPublish::Berry {
+            version: version.to_string(),
+            dry_run,
+        })
+    };
+
+    for (reported, expected) in [
+        ("1.22.22", Some(YarnPublish::Classic)),
+        ("2.4.3", berry("2.4.3", false)),
+        ("3.8.7", berry("3.8.7", false)),
+        ("4.9.2", berry("4.9.2", false)),
+        ("4.9.3", berry("4.9.3", true)),
+        ("4.18.0\n", berry("4.18.0", true)),
+        ("not a version", None),
+    ] {
+        assert_eq!(super::classify_yarn(reported), expected, "{reported:?}");
+    }
+}
+
+#[test]
+fn dry_run_gap_is_reported_only_when_yarn_cannot_simulate() {
+    let classic = YarnPublish::Classic
+        .dry_run_gap()
+        .expect("classic has no dry run");
+    assert!(classic.contains("Classic"), "{classic}");
+
+    let old_berry = YarnPublish::Berry {
+        version: "4.9.2".to_string(),
+        dry_run: false,
+    }
+    .dry_run_gap()
+    .expect("berry below the floor has no dry run");
+    assert!(
+        old_berry.contains("4.9.2") && old_berry.contains("4.9.3"),
+        "must name the version found and the one required: {old_berry}"
+    );
+
+    assert_eq!(
+        YarnPublish::Berry {
+            version: "4.18.0".to_string(),
+            dry_run: true,
+        }
+        .dry_run_gap(),
+        None
+    );
+}
+
+#[test]
+fn publish_command_args_namespace_publishing_under_npm_on_berry_only() {
+    let info = manifest_info("pkg");
+    let berry = YarnPublish::Berry {
+        version: "4.18.0".to_string(),
+        dry_run: true,
+    };
+
+    assert_eq!(
+        super::publish_command_args(Some(&berry), true, &info, &[]),
+        ["npm", "publish", "--dry-run"]
+    );
+    assert_eq!(
+        super::publish_command_args(Some(&YarnPublish::Classic), false, &info, &[]),
+        ["publish"]
+    );
+    assert_eq!(
+        super::publish_command_args(None, true, &info, &[]),
+        ["publish", "--dry-run"]
+    );
+}
+
+#[test]
+fn publish_command_args_keep_the_existing_flag_handling() {
+    let mut info = manifest_info("@scope/pkg");
+    info.publish_config.registry = Some("https://example.test/".to_string());
+    info.publish_config.tag = Some("next".to_string());
+
+    assert_eq!(
+        super::publish_command_args(None, true, &info, &[]),
+        [
+            "publish",
+            "--dry-run",
+            "--registry",
+            "https://example.test/",
+            "--access",
+            "public",
+            "--tag",
+            "next",
+        ]
+    );
+
+    let overrides = ["--tag".to_string(), "beta".to_string()];
+    assert_eq!(
+        super::publish_command_args(None, false, &info, &overrides),
+        [
+            "publish",
+            "--registry",
+            "https://example.test/",
+            "--access",
+            "public",
+            "--tag",
+            "beta",
+        ]
+    );
+}
+
+#[test]
+fn publish_command_args_omit_registry_on_berry_which_rejects_the_flag() {
+    let mut info = manifest_info("@scope/pkg");
+    info.publish_config.registry = Some("https://example.test/".to_string());
+    info.publish_config.tag = Some("next".to_string());
+    let berry = YarnPublish::Berry {
+        version: "4.18.0".to_string(),
+        dry_run: true,
+    };
+
+    assert_eq!(
+        super::publish_command_args(Some(&berry), true, &info, &[]),
+        [
+            "npm",
+            "publish",
+            "--dry-run",
+            "--access",
+            "public",
+            "--tag",
+            "next"
+        ]
+    );
+    assert_eq!(
+        super::publish_command_args(Some(&YarnPublish::Classic), false, &info, &[]),
+        [
+            "publish",
+            "--registry",
+            "https://example.test/",
+            "--access",
+            "public",
+            "--tag",
+            "next"
+        ]
+    );
+}
+
+#[test]
+fn wants_dry_run_covers_the_ecosystem_passthrough() {
+    let negated = ["--dry-run=false".to_string()];
+    assert!(super::wants_dry_run(true, &[]));
+    assert!(super::wants_dry_run(false, &["--dry-run".to_string()]));
+    assert!(super::wants_dry_run(false, &["--dry-run=true".to_string()]));
+    assert!(!super::wants_dry_run(false, &[]));
+    assert!(!super::wants_dry_run(false, &["--access".to_string()]));
+    assert!(!super::wants_dry_run(false, &["--dry-runner".to_string()]));
+
+    assert!(!super::wants_dry_run(false, &negated));
+    assert!(!super::wants_dry_run(false, &["--dry-run=0".to_string()]));
+    assert!(super::wants_dry_run(true, &negated));
+}
+
+#[test]
+fn publish_command_args_do_not_repeat_a_passthrough_dry_run() {
+    let info = manifest_info("pkg");
+    let passthrough = ["--dry-run".to_string()];
+
+    assert_eq!(
+        super::publish_command_args(None, true, &info, &passthrough),
+        ["publish", "--dry-run"]
+    );
+    let berry = YarnPublish::Berry {
+        version: "4.18.0".to_string(),
+        dry_run: true,
+    };
+    assert_eq!(
+        super::publish_command_args(Some(&berry), true, &info, &passthrough),
+        ["npm", "publish", "--dry-run"]
+    );
+}

--- a/crates/sampo-core/src/adapters/packagist.rs
+++ b/crates/sampo-core/src/adapters/packagist.rs
@@ -319,7 +319,7 @@ impl PackagistAdapter {
 pub(super) fn publish_dry_run(
     packages: &[(&PackageInfo, &Path)],
     extra_args: &[String],
-) -> Result<()> {
+) -> Result<Vec<String>> {
     for (package, manifest) in packages {
         PackagistAdapter
             .publish(manifest, true, extra_args)
@@ -333,7 +333,7 @@ pub(super) fn publish_dry_run(
             })?;
     }
 
-    Ok(())
+    Ok(Vec::new())
 }
 
 pub(super) fn check_dependency_constraint(

--- a/crates/sampo-core/src/adapters/pypi.rs
+++ b/crates/sampo-core/src/adapters/pypi.rs
@@ -187,7 +187,7 @@ pub(super) fn check_dependency_constraint(
 pub(super) fn publish_dry_run(
     packages: &[(&PackageInfo, &Path)],
     extra_args: &[String],
-) -> Result<()> {
+) -> Result<Vec<String>> {
     for (package, manifest) in packages {
         PyPIAdapter
             .publish(manifest, true, extra_args)
@@ -201,7 +201,7 @@ pub(super) fn publish_dry_run(
             })?;
     }
 
-    Ok(())
+    Ok(Vec::new())
 }
 
 fn enforce_pypi_rate_limit() {

--- a/crates/sampo-core/src/publish.rs
+++ b/crates/sampo-core/src/publish.rs
@@ -1,4 +1,4 @@
-use crate::adapters::PackageAdapter;
+use crate::adapters::{PackageAdapter, PublishOutcome};
 use crate::tag_template::Placeholder;
 use crate::types::{PackageInfo, PackageKind, PublishOutput};
 use crate::{
@@ -240,21 +240,32 @@ pub fn run_publish(
                 .push((*package, manifest.as_path()));
         }
 
+        let mut not_validated: Vec<String> = Vec::new();
         for (kind, packages) in &packages_by_kind {
             let adapter = PackageAdapter::from_kind(*kind);
             let args = extra_args.args_for_kind(*kind);
-            adapter.publish_dry_run(&ws.root, packages, &args)?;
+            not_validated.extend(adapter.publish_dry_run(&ws.root, packages, &args)?);
         }
 
-        println!("Dry-run validation passed.");
+        if not_validated.is_empty() {
+            println!("Dry-run validation passed.");
+        } else {
+            println!(
+                "Dry-run validation incomplete: {} could not be validated. Will attempt publish.",
+                not_validated.join(", ")
+            );
+        }
     }
 
     let mut tags_to_create: Vec<String> = Vec::new();
     let mut any_published = false;
+    let mut not_simulated: Vec<String> = Vec::new();
 
     for (package, adapter, manifest) in &publish_targets {
         let args = extra_args.args_for_kind(package.kind);
-        adapter.publish(manifest.as_path(), dry_run, &args)?;
+        if adapter.publish(manifest.as_path(), dry_run, &args)? == PublishOutcome::DryRunSkipped {
+            not_simulated.push(package.display_name(true));
+        }
         any_published = true;
 
         // Publishable packages always carry a version, so the tag is well-formed.
@@ -342,8 +353,17 @@ pub fn run_publish(
 
     if dry_run {
         println!("Dry-run complete.");
+        if !not_simulated.is_empty() {
+            println!("{} could not be validated.", not_simulated.join(", "));
+        }
     } else {
         println!("Publish complete.");
+        if !not_simulated.is_empty() {
+            eprintln!(
+                "Warning: {} did not reach the registry: the publish was skipped as a dry run, but the release was still tagged.",
+                not_simulated.join(", ")
+            );
+        }
     }
 
     Ok(PublishOutput {

--- a/crates/sampo-core/tests/cargo_publish_dry_run.rs
+++ b/crates/sampo-core/tests/cargo_publish_dry_run.rs
@@ -1,0 +1,167 @@
+//! Its own test binary: it overrides `PATH` process-wide.
+#![cfg(unix)]
+
+mod common;
+
+use sampo_core::adapters::PackageAdapter;
+use sampo_core::types::{PackageInfo, PackageKind};
+use std::collections::BTreeSet;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+
+/// Records every argv. Anything but `--version` succeeds, so a spawned dry run cannot
+/// fail for unrelated reasons.
+fn write_fake_cargo(dir: &Path, argv_log: &Path, version: &str) {
+    fs::create_dir_all(dir).unwrap();
+    let stub = dir.join("cargo");
+    fs::write(
+        &stub,
+        format!(
+            "#!/bin/sh\n\
+             printf '%s\\n' \"$*\" >> '{}'\n\
+             if [ \"$1\" = \"--version\" ]; then echo 'cargo {version} (stub)'; fi\n\
+             exit 0\n",
+            argv_log.display()
+        ),
+    )
+    .unwrap();
+    fs::set_permissions(&stub, fs::Permissions::from_mode(0o755)).unwrap();
+}
+
+fn write_crate(root: &Path, name: &str) -> PathBuf {
+    let dir = root.join(name);
+    fs::create_dir_all(&dir).unwrap();
+    let manifest = dir.join("Cargo.toml");
+    fs::write(
+        &manifest,
+        format!("[package]\nname = \"{name}\"\nversion = \"1.0.0\"\n"),
+    )
+    .unwrap();
+    manifest
+}
+
+fn package(name: &str, manifest: &Path, internal_deps: &[&str]) -> PackageInfo {
+    PackageInfo {
+        name: name.to_string(),
+        identifier: format!("cargo/{name}"),
+        version: "1.0.0".to_string(),
+        path: manifest.parent().unwrap().to_path_buf(),
+        internal_deps: internal_deps.iter().map(|d| d.to_string()).collect(),
+        internal_dev_deps: BTreeSet::new(),
+        kind: PackageKind::Cargo,
+    }
+}
+
+fn argv_lines(argv_log: &Path) -> Vec<String> {
+    fs::read_to_string(argv_log)
+        .unwrap_or_default()
+        .lines()
+        .map(str::to_string)
+        .collect()
+}
+
+struct Fixture {
+    _temp: tempfile::TempDir,
+    root: PathBuf,
+    leaf_manifest: PathBuf,
+    dependent_manifest: PathBuf,
+    argv_log: PathBuf,
+    _guard: std::sync::MutexGuard<'static, ()>,
+}
+
+impl Fixture {
+    fn new(cargo_version: &str) -> Self {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path().to_path_buf();
+        let argv_log = root.join("cargo-argv.log");
+        let bin = root.join("fake-bin");
+
+        let leaf_manifest = write_crate(&root, "leaf");
+        let dependent_manifest = write_crate(&root, "dependent");
+        write_fake_cargo(&bin, &argv_log, cargo_version);
+        let guard = common::use_only(&bin);
+
+        Self {
+            _temp: temp,
+            root,
+            leaf_manifest,
+            dependent_manifest,
+            argv_log,
+            _guard: guard,
+        }
+    }
+
+    fn dry_run(&self) -> Vec<String> {
+        let leaf = package("leaf", &self.leaf_manifest, &[]);
+        let dependent = package("dependent", &self.dependent_manifest, &["cargo/leaf"]);
+        PackageAdapter::Cargo
+            .publish_dry_run(
+                &self.root,
+                &[
+                    (&leaf, self.leaf_manifest.as_path()),
+                    (&dependent, self.dependent_manifest.as_path()),
+                ],
+                &[],
+            )
+            .expect("the stub cargo accepts every invocation")
+    }
+
+    fn argv(&self) -> Vec<String> {
+        argv_lines(&self.argv_log)
+    }
+}
+
+#[test]
+fn a_cargo_without_workspace_dry_run_reports_the_crates_it_skipped() {
+    let fixture = Fixture::new("1.90.0");
+
+    let skipped = fixture.dry_run();
+
+    assert_eq!(
+        skipped,
+        ["dependent (Cargo)"],
+        "a skip must reach the caller, which would otherwise report a validation that never ran"
+    );
+
+    let argv = fixture.argv();
+    assert_eq!(
+        argv.len(),
+        2,
+        "only the version probe and the leaf's dry run may be spawned: {argv:?}"
+    );
+    assert_eq!(argv[0], "--version");
+    assert!(
+        argv[1].contains("publish --manifest-path")
+            && argv[1].contains(fixture.leaf_manifest.to_str().unwrap())
+            && argv[1].ends_with("--dry-run"),
+        "the leaf must still be validated: {argv:?}"
+    );
+    assert!(
+        !argv[1].contains(fixture.dependent_manifest.to_str().unwrap()),
+        "the dependent crate must not be spawned: {argv:?}"
+    );
+}
+
+#[test]
+fn a_workspace_aware_cargo_skips_nothing() {
+    let fixture = Fixture::new("1.91.0");
+
+    let skipped = fixture.dry_run();
+
+    assert!(
+        skipped.is_empty(),
+        "a workspace dry run validates every crate, dependent ones included: {skipped:?}"
+    );
+    assert_eq!(
+        fixture.argv().len(),
+        2,
+        "the version probe plus a single workspace dry run: {:?}",
+        fixture.argv()
+    );
+    assert!(
+        fixture.argv()[1].contains("publish --workspace --dry-run"),
+        "{:?}",
+        fixture.argv()
+    );
+}

--- a/crates/sampo-core/tests/yarn_publish_dry_run.rs
+++ b/crates/sampo-core/tests/yarn_publish_dry_run.rs
@@ -1,0 +1,183 @@
+//! Its own test binary: it overrides `PATH` process-wide.
+#![cfg(unix)]
+
+mod common;
+
+use sampo_core::adapters::PackageAdapter;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+
+fn write_yarn_package(dir: &Path, yarn_version: &str) -> PathBuf {
+    let manifest = dir.join("package.json");
+    fs::write(
+        &manifest,
+        format!(r#"{{"name":"pkg","version":"1.0.0","packageManager":"yarn@{yarn_version}"}}"#),
+    )
+    .unwrap();
+    manifest
+}
+
+/// Records every argv. Anything but `--version` fails, which keeps the spawned case off
+/// the network.
+fn write_fake_yarn(dir: &Path, argv_log: &Path, version: &str) {
+    fs::create_dir_all(dir).unwrap();
+    let stub = dir.join("yarn");
+    fs::write(
+        &stub,
+        format!(
+            "#!/bin/sh\n\
+             printf '%s\\n' \"$*\" >> '{}'\n\
+             if [ \"$1\" = \"--version\" ]; then echo {version}; exit 0; fi\n\
+             exit 1\n",
+            argv_log.display()
+        ),
+    )
+    .unwrap();
+    fs::set_permissions(&stub, fs::Permissions::from_mode(0o755)).unwrap();
+}
+
+fn argv_lines(argv_log: &Path) -> Vec<String> {
+    fs::read_to_string(argv_log)
+        .unwrap_or_default()
+        .lines()
+        .map(str::to_string)
+        .collect()
+}
+
+struct Fixture {
+    _temp: tempfile::TempDir,
+    manifest: PathBuf,
+    argv_log: PathBuf,
+    _guard: std::sync::MutexGuard<'static, ()>,
+}
+
+impl Fixture {
+    fn new(yarn_version: &str) -> Self {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        let argv_log = root.join("yarn-argv.log");
+        let bin = root.join("fake-bin");
+
+        let manifest = write_yarn_package(root, yarn_version);
+        write_fake_yarn(&bin, &argv_log, yarn_version);
+        let guard = common::use_only(&bin);
+
+        Self {
+            _temp: temp,
+            manifest,
+            argv_log,
+            _guard: guard,
+        }
+    }
+
+    fn argv(&self) -> Vec<String> {
+        argv_lines(&self.argv_log)
+    }
+}
+
+#[test]
+fn yarn_classic_dry_run_is_skipped_without_spawning_a_publish() {
+    let fixture = Fixture::new("1.22.22");
+
+    PackageAdapter::Npm
+        .publish(&fixture.manifest, true, &[])
+        .expect("a dry run yarn cannot simulate must be skipped, not failed");
+
+    assert_eq!(
+        fixture.argv(),
+        ["--version"],
+        "nothing but the version probe may be spawned"
+    );
+}
+
+#[test]
+fn yarn_berry_below_the_dry_run_floor_is_skipped_without_spawning_a_publish() {
+    let fixture = Fixture::new("4.9.2");
+
+    PackageAdapter::Npm
+        .publish(&fixture.manifest, true, &[])
+        .expect("`yarn npm publish` gained --dry-run in 4.9.3");
+
+    assert_eq!(
+        fixture.argv(),
+        ["--version"],
+        "nothing but the version probe may be spawned"
+    );
+}
+
+#[test]
+fn yarn_berry_at_the_dry_run_floor_reaches_yarn_npm_publish() {
+    let fixture = Fixture::new("4.9.3");
+
+    let err = PackageAdapter::Npm
+        .publish(&fixture.manifest, true, &[])
+        .expect_err("the stub yarn fails the publish");
+    assert!(
+        err.to_string().contains("pkg"),
+        "the failure must be the spawned publish: {err}"
+    );
+
+    assert_eq!(
+        fixture.argv(),
+        ["--version", "npm publish --dry-run"],
+        "a yarn with a dry run must run it, namespaced under `npm`"
+    );
+}
+
+#[test]
+fn a_real_publish_is_never_skipped_on_a_yarn_without_a_dry_run() {
+    let fixture = Fixture::new("1.22.22");
+
+    let err = PackageAdapter::Npm
+        .publish(&fixture.manifest, false, &[])
+        .expect_err("the stub yarn fails the publish");
+    assert!(
+        err.to_string().contains("pkg"),
+        "the failure must be the spawned publish: {err}"
+    );
+
+    assert_eq!(
+        fixture.argv(),
+        ["--version", "publish"],
+        "the skip covers dry runs only; a real publish must still be spawned"
+    );
+}
+
+#[test]
+fn a_dry_run_asked_for_through_the_passthrough_is_skipped_too() {
+    let fixture = Fixture::new("1.22.22");
+
+    // `sampo publish -- --dry-run` reaches the adapter as a plain publish carrying the flag.
+    PackageAdapter::Npm
+        .publish(&fixture.manifest, false, &["--dry-run".to_string()])
+        .expect("a dry run yarn cannot simulate must be skipped, not failed");
+
+    assert_eq!(
+        fixture.argv(),
+        ["--version"],
+        "nothing but the version probe may be spawned"
+    );
+}
+
+#[test]
+fn the_probe_wins_over_the_manifest_field() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    let argv_log = root.join("yarn-argv.log");
+    let bin = root.join("fake-bin");
+
+    let manifest = write_yarn_package(root, "1.22.22");
+    write_fake_yarn(&bin, &argv_log, "4.9.3");
+    let _guard = common::use_only(&bin);
+
+    PackageAdapter::Npm
+        .publish(&manifest, true, &[])
+        .expect_err("the stub yarn fails the publish");
+
+    assert_eq!(
+        argv_lines(&argv_log),
+        ["--version", "npm publish --dry-run"],
+        "the reported version must decide, not the packageManager field"
+    );
+}

--- a/crates/sampo-core/tests/yarn_publish_dry_run.rs
+++ b/crates/sampo-core/tests/yarn_publish_dry_run.rs
@@ -3,7 +3,9 @@
 
 mod common;
 
-use sampo_core::adapters::PackageAdapter;
+use sampo_core::adapters::{PackageAdapter, PublishOutcome};
+use sampo_core::types::{PackageInfo, PackageKind};
+use std::collections::BTreeSet;
 use std::fs;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
@@ -18,9 +20,9 @@ fn write_yarn_package(dir: &Path, yarn_version: &str) -> PathBuf {
     manifest
 }
 
-/// Records every argv. Anything but `--version` fails, which keeps the spawned case off
-/// the network.
-fn write_fake_yarn(dir: &Path, argv_log: &Path, version: &str) {
+/// Records every argv. Anything but `--version` exits with `exit_code`: 1 keeps the
+/// spawned case off the network.
+fn write_fake_yarn(dir: &Path, argv_log: &Path, version: &str, exit_code: u8) {
     fs::create_dir_all(dir).unwrap();
     let stub = dir.join("yarn");
     fs::write(
@@ -29,7 +31,7 @@ fn write_fake_yarn(dir: &Path, argv_log: &Path, version: &str) {
             "#!/bin/sh\n\
              printf '%s\\n' \"$*\" >> '{}'\n\
              if [ \"$1\" = \"--version\" ]; then echo {version}; exit 0; fi\n\
-             exit 1\n",
+             exit {exit_code}\n",
             argv_log.display()
         ),
     )
@@ -54,13 +56,22 @@ struct Fixture {
 
 impl Fixture {
     fn new(yarn_version: &str) -> Self {
+        Self::build(yarn_version, 1)
+    }
+
+    /// A yarn whose publish succeeds.
+    fn permissive(yarn_version: &str) -> Self {
+        Self::build(yarn_version, 0)
+    }
+
+    fn build(yarn_version: &str, exit_code: u8) -> Self {
         let temp = tempfile::tempdir().unwrap();
         let root = temp.path();
         let argv_log = root.join("yarn-argv.log");
         let bin = root.join("fake-bin");
 
         let manifest = write_yarn_package(root, yarn_version);
-        write_fake_yarn(&bin, &argv_log, yarn_version);
+        write_fake_yarn(&bin, &argv_log, yarn_version, exit_code);
         let guard = common::use_only(&bin);
 
         Self {
@@ -74,16 +85,33 @@ impl Fixture {
     fn argv(&self) -> Vec<String> {
         argv_lines(&self.argv_log)
     }
+
+    fn package(&self) -> PackageInfo {
+        PackageInfo {
+            name: "pkg".to_string(),
+            identifier: "npm/pkg".to_string(),
+            version: "1.0.0".to_string(),
+            path: self.manifest.parent().unwrap().to_path_buf(),
+            internal_deps: BTreeSet::new(),
+            internal_dev_deps: BTreeSet::new(),
+            kind: PackageKind::Npm,
+        }
+    }
 }
 
 #[test]
 fn yarn_classic_dry_run_is_skipped_without_spawning_a_publish() {
     let fixture = Fixture::new("1.22.22");
 
-    PackageAdapter::Npm
+    let outcome = PackageAdapter::Npm
         .publish(&fixture.manifest, true, &[])
         .expect("a dry run yarn cannot simulate must be skipped, not failed");
 
+    assert_eq!(
+        outcome,
+        PublishOutcome::DryRunSkipped,
+        "the skip must reach the caller, which reports what went unvalidated"
+    );
     assert_eq!(
         fixture.argv(),
         ["--version"],
@@ -92,13 +120,54 @@ fn yarn_classic_dry_run_is_skipped_without_spawning_a_publish() {
 }
 
 #[test]
+fn a_skipped_dry_run_is_reported_to_the_caller() {
+    let fixture = Fixture::new("1.22.22");
+    let package = fixture.package();
+
+    let skipped = PackageAdapter::Npm
+        .publish_dry_run(
+            fixture.manifest.parent().unwrap(),
+            &[(&package, fixture.manifest.as_path())],
+            &[],
+        )
+        .expect("a dry run yarn cannot simulate must be skipped, not failed");
+
+    assert_eq!(
+        skipped,
+        [package.display_name(true)],
+        "a skip must reach the caller, which would otherwise report a validation that never ran"
+    );
+}
+
+#[test]
+fn a_validated_dry_run_reports_nothing_skipped() {
+    let fixture = Fixture::permissive("4.9.3");
+    let package = fixture.package();
+
+    let skipped = PackageAdapter::Npm
+        .publish_dry_run(
+            fixture.manifest.parent().unwrap(),
+            &[(&package, fixture.manifest.as_path())],
+            &[],
+        )
+        .expect("the stub yarn accepts the dry run");
+
+    assert!(
+        skipped.is_empty(),
+        "a yarn that simulated the publish leaves nothing unvalidated: {skipped:?}"
+    );
+    assert_eq!(fixture.argv(), ["--version", "npm publish --dry-run"]);
+}
+
+#[test]
 fn yarn_berry_below_the_dry_run_floor_is_skipped_without_spawning_a_publish() {
     let fixture = Fixture::new("4.9.2");
 
-    PackageAdapter::Npm
+    let outcome = PackageAdapter::Npm
         .publish(&fixture.manifest, true, &[])
         .expect("`yarn npm publish` gained --dry-run in 4.9.3");
 
+    assert_eq!(outcome, PublishOutcome::DryRunSkipped);
     assert_eq!(
         fixture.argv(),
         ["--version"],
@@ -114,8 +183,8 @@ fn yarn_berry_at_the_dry_run_floor_reaches_yarn_npm_publish() {
         .publish(&fixture.manifest, true, &[])
         .expect_err("the stub yarn fails the publish");
     assert!(
-        err.to_string().contains("pkg"),
-        "the failure must be the spawned publish: {err}"
+        err.to_string().contains("yarn npm publish failed"),
+        "the failure must name the command that actually ran: {err}"
     );
 
     assert_eq!(
@@ -133,8 +202,8 @@ fn a_real_publish_is_never_skipped_on_a_yarn_without_a_dry_run() {
         .publish(&fixture.manifest, false, &[])
         .expect_err("the stub yarn fails the publish");
     assert!(
-        err.to_string().contains("pkg"),
-        "the failure must be the spawned publish: {err}"
+        err.to_string().contains("yarn publish failed"),
+        "the failure must name the command that actually ran: {err}"
     );
 
     assert_eq!(
@@ -168,7 +237,7 @@ fn the_probe_wins_over_the_manifest_field() {
     let bin = root.join("fake-bin");
 
     let manifest = write_yarn_package(root, "1.22.22");
-    write_fake_yarn(&bin, &argv_log, "4.9.3");
+    write_fake_yarn(&bin, &argv_log, "4.9.3", 1);
     let _guard = common::use_only(&bin);
 
     PackageAdapter::Npm


### PR DESCRIPTION
## What has changed?

Fixes #310. Sampo now reads the yarn version before publishing: Berry gets `yarn npm publish`, and a yarn that cannot simulate a publish gets its dry run skipped with a warning, rather than a command that publishes for real.

The dry run also serves as a pre-flight before every real publish, so a plain `sampo publish` was affected too, not just `--dry-run`.

## How is it tested?

Unit tests on the version classification and the argument vectors, plus integration tests driving `PackageAdapter::publish` against a stand-in `yarn` on `PATH`. The real `yarn` subprocess is not exercised (no toolchain in CI) as with the other adapters.

## How is it documented?

N/A