### PR TITLE
feat(core): honour .gitignore during package scanning

### DIFF
--- a/.sampo/changesets/honest-gitignore-vainamoinen.md
+++ b/.sampo/changesets/honest-gitignore-vainamoinen.md
@@ -1,0 +1,7 @@
+---
+cargo/sampo: minor
+cargo/sampo-core: minor
+cargo/sampo-github-action: minor
+---
+
+In Python (PyPI), Gleam (Hex), and Erlang (Hex) projects, changed package scanning to honour `.gitignore` files: gitignored manifests are skipped, and virtual environments self-exclude through the catch-all `.gitignore` written by uv and `python -m venv` (Python 3.13+). Only `.gitignore` files inside the project are read, never the global gitignore, so local and CI scans agree.

--- a/.sampo/changesets/honest-gitignore-vainamoinen.md
+++ b/.sampo/changesets/honest-gitignore-vainamoinen.md
@@ -4,4 +4,4 @@ cargo/sampo-core: minor
 cargo/sampo-github-action: minor
 ---
 
-In Python (PyPI), Gleam (Hex), and Erlang (Hex) projects, changed package scanning to honour `.gitignore` files: gitignored manifests are skipped, and virtual environments self-exclude through the catch-all `.gitignore` written by uv and `python -m venv` (Python 3.13+). Only `.gitignore` files inside the project are read, never the global gitignore, so local and CI scans agree.
+In Python (PyPI), Gleam (Hex), and Erlang (Hex) projects, changed package scanning to honour `.gitignore` files: gitignored manifests are skipped, and virtual environments self-exclude through the catch-all `.gitignore` written by uv and `python -m venv` (Python 3.13+). Only `.gitignore` files inside the project are read — never your personal global gitignore (`core.excludesFile`) — so local and CI scans agree.

--- a/.sampo/changesets/honest-gitignore-vainamoinen.md
+++ b/.sampo/changesets/honest-gitignore-vainamoinen.md
@@ -4,4 +4,4 @@ cargo/sampo-core: minor
 cargo/sampo-github-action: minor
 ---
 
-In Python (PyPI), Gleam (Hex), and Erlang (Hex) projects, changed package scanning to honour `.gitignore` files: gitignored manifests are skipped, and virtual environments self-exclude through the catch-all `.gitignore` written by uv and `python -m venv` (Python 3.13+). Only `.gitignore` files inside the project are read — never your personal global gitignore (`core.excludesFile`) — so local and CI scans agree.
+In Python (PyPI), Gleam (Hex), and Erlang (Hex) projects, package scanning now honours `.gitignore` files: gitignored manifests are skipped, and virtual environments self-exclude through the catch-all `.gitignore` written by uv and `python -m venv` (Python 3.13+). Only `.gitignore` files inside the repository are read — never your personal global gitignore (`core.excludesFile`) — so local and CI scans agree.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -244,6 +244,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bb31b46c14244e20ee9984b11bf5c992b91fb6939fea616e3512c8baecdbe5f"
+dependencies = [
+ "memchr",
+ "serde_core",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -535,6 +545,31 @@ checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61803da095bee82a81bb1a452ecc25d3b2f1416d1897eb86430c6159ef717c17"
 
 [[package]]
 name = "crypto-bigint"
@@ -1002,6 +1037,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
+name = "globset"
+version = "0.4.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07c34a9410465b45bd9787443bc7370f37735bad04b0f0cd57ff1a3186c98988"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "group"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1336,6 +1384,22 @@ checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "ignore"
+version = "0.4.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b69833ed729dc5aa7d19541d96d6cf8e9137194207a04916d658e43168402f"
+dependencies = [
+ "crossbeam-deque",
+ "globset",
+ "log",
+ "memchr",
+ "regex-automata",
+ "same-file",
+ "walkdir",
+ "winapi-util",
 ]
 
 [[package]]
@@ -2301,6 +2365,7 @@ dependencies = [
  "chrono",
  "chrono-tz",
  "glob",
+ "ignore",
  "reqwest",
  "rustc-hash",
  "semver",

--- a/crates/sampo-core/Cargo.toml
+++ b/crates/sampo-core/Cargo.toml
@@ -14,6 +14,7 @@ categories = ["development-tools"]
 [dependencies]
 cargo_metadata = "0.23"
 glob = "0.3"
+ignore = "0.4"
 rustc-hash = "2.0"
 thiserror = "2.0"
 toml = "1"

--- a/crates/sampo-core/src/adapters.rs
+++ b/crates/sampo-core/src/adapters.rs
@@ -57,6 +57,17 @@ impl PackageAdapter {
         }
     }
 
+    /// [`Self::can_discover`] sharing one discovery pass's scan.
+    pub(crate) fn can_discover_scanned(&self, scan: &scan::LazyScan) -> bool {
+        match self {
+            Self::Hex => hex::HexAdapter.can_discover_scanned(scan),
+            Self::PyPI => pypi::PyPIAdapter.can_discover_scanned(scan),
+            Self::Cargo | Self::Npm | Self::Packagist | Self::Maven => {
+                self.can_discover(scan.root())
+            }
+        }
+    }
+
     /// Discover all packages in the workspace.
     pub fn discover(&self, root: &Path) -> std::result::Result<Vec<PackageInfo>, WorkspaceError> {
         match self {
@@ -66,6 +77,18 @@ impl PackageAdapter {
             Self::PyPI => pypi::PyPIAdapter.discover(root),
             Self::Packagist => packagist::PackagistAdapter.discover(root),
             Self::Maven => maven::MavenAdapter.discover(root),
+        }
+    }
+
+    /// [`Self::discover`] sharing one discovery pass's scan.
+    pub(crate) fn discover_scanned(
+        &self,
+        scan: &scan::LazyScan,
+    ) -> std::result::Result<Vec<PackageInfo>, WorkspaceError> {
+        match self {
+            Self::Hex => hex::HexAdapter.discover_scanned(scan),
+            Self::PyPI => pypi::PyPIAdapter.discover_scanned(scan),
+            Self::Cargo | Self::Npm | Self::Packagist | Self::Maven => self.discover(scan.root()),
         }
     }
 

--- a/crates/sampo-core/src/adapters/hex.rs
+++ b/crates/sampo-core/src/adapters/hex.rs
@@ -1,4 +1,5 @@
 use crate::adapters::require_on_path;
+use crate::adapters::scan::LazyScan;
 use crate::errors::{Result, SampoError, WorkspaceError};
 use crate::types::PackageInfo;
 use reqwest::StatusCode;
@@ -25,24 +26,37 @@ pub(super) struct HexAdapter;
 
 impl HexAdapter {
     pub(super) fn can_discover(&self, root: &Path) -> bool {
-        mix::can_discover(root) || gleam::can_discover(root) || rebar3::can_discover(root)
+        self.can_discover_scanned(&LazyScan::new(root))
+    }
+
+    pub(super) fn can_discover_scanned(&self, scan: &LazyScan) -> bool {
+        mix::can_discover(scan.root())
+            || gleam::can_discover_scanned(scan)
+            || rebar3::can_discover_scanned(scan)
     }
 
     pub(super) fn discover(
         &self,
         root: &Path,
     ) -> std::result::Result<Vec<PackageInfo>, WorkspaceError> {
+        self.discover_scanned(&LazyScan::new(root))
+    }
+
+    pub(super) fn discover_scanned(
+        &self,
+        scan: &LazyScan,
+    ) -> std::result::Result<Vec<PackageInfo>, WorkspaceError> {
         // Elixir, Gleam, and Erlang packages can live side by side in a BEAM monorepo;
         // each build tool discovers its own members and they merge into one Hex workspace.
         let mut packages = Vec::new();
-        if mix::can_discover(root) {
-            packages.extend(mix::discover(root)?);
+        if mix::can_discover(scan.root()) {
+            packages.extend(mix::discover(scan.root())?);
         }
-        if gleam::can_discover(root) {
-            packages.extend(gleam::discover(root)?);
+        if gleam::can_discover_scanned(scan) {
+            packages.extend(gleam::discover_scanned(scan)?);
         }
-        if rebar3::can_discover(root) {
-            packages.extend(rebar3::discover(root)?);
+        if rebar3::can_discover_scanned(scan) {
+            packages.extend(rebar3::discover_scanned(scan)?);
         }
         Ok(packages)
     }

--- a/crates/sampo-core/src/adapters/hex/gleam.rs
+++ b/crates/sampo-core/src/adapters/hex/gleam.rs
@@ -379,12 +379,14 @@ fn collect_dependencies(doc: &toml::Value, manifest_dir: &Path) -> Vec<ParsedDep
 
 fn find_manifests(root: &Path) -> Vec<PathBuf> {
     let mut out = Vec::new();
-    crate::adapters::scan::walk_package_dirs(root, &[], |dir| {
+    crate::adapters::scan::walk_package_dirs(root, &[], |dir, gitignore| {
         let manifest = dir.join(GLEAM_MANIFEST);
-        // A directory carrying both manifests is a Mix project that also holds Gleam
-        // sources (the mix_gleam interop): Mix owns its identity and publish path, so the
-        // Gleam scan skips it to avoid discovering the same package twice.
-        if manifest.is_file() && !dir.join("mix.exs").exists() {
+        // A `mix.exs` alongside is the mix_gleam interop: Mix owns the
+        // package, so skip it to avoid double discovery.
+        if manifest.is_file()
+            && !dir.join("mix.exs").exists()
+            && !gitignore.is_ignored(dir, &manifest)
+        {
             out.push(manifest);
         }
     });

--- a/crates/sampo-core/src/adapters/hex/gleam.rs
+++ b/crates/sampo-core/src/adapters/hex/gleam.rs
@@ -1,3 +1,4 @@
+use crate::adapters::scan::{LazyScan, ScanIndex};
 use crate::adapters::{format_command_display, has_flag};
 use crate::errors::{Result, SampoError, WorkspaceError};
 use crate::process::command;
@@ -13,15 +14,28 @@ use super::{GLEAM_MANIFEST, compute_requirement, normalize_path};
 const GLEAM_LOCKFILE: &str = "manifest.toml";
 
 pub(super) fn can_discover(root: &Path) -> bool {
-    !find_manifests(root).is_empty()
+    can_discover_scanned(&LazyScan::new(root))
 }
 
+pub(super) fn can_discover_scanned(scan: &LazyScan) -> bool {
+    !find_manifests(scan.index()).is_empty()
+}
+
+/// Test-only entry: production discovery always shares the pass's [`LazyScan`].
+#[cfg(test)]
 pub(super) fn discover(root: &Path) -> std::result::Result<Vec<PackageInfo>, WorkspaceError> {
+    discover_scanned(&LazyScan::new(root))
+}
+
+pub(super) fn discover_scanned(
+    scan: &LazyScan,
+) -> std::result::Result<Vec<PackageInfo>, WorkspaceError> {
+    let root = scan.root();
     let mut name_to_path: BTreeMap<String, PathBuf> = BTreeMap::new();
     let mut normalized_to_name: BTreeMap<PathBuf, String> = BTreeMap::new();
     let mut parsed = Vec::new();
 
-    for manifest_path in find_manifests(root) {
+    for manifest_path in find_manifests(scan.index()) {
         let dir = manifest_path
             .parent()
             .map(Path::to_path_buf)
@@ -187,18 +201,20 @@ pub(super) fn publish(manifest_path: &Path, dry_run: bool, extra_args: &[String]
 /// Narrower than [`can_discover`]: a `gleam.toml` with no lockfile yet is discovered but
 /// never regenerated.
 pub(super) fn has_lockfile_to_regenerate(workspace_root: &Path) -> bool {
-    find_manifests(workspace_root).iter().any(|manifest_path| {
-        manifest_path
-            .parent()
-            .is_some_and(|dir| dir.join(GLEAM_LOCKFILE).exists())
-    })
+    find_manifests(&ScanIndex::build(workspace_root))
+        .iter()
+        .any(|manifest_path| {
+            manifest_path
+                .parent()
+                .is_some_and(|dir| dir.join(GLEAM_LOCKFILE).exists())
+        })
 }
 
 pub(super) fn regenerate_lockfile(workspace_root: &Path) -> Result<()> {
     // Each Gleam package owns its `manifest.toml`; refresh every one that already
     // exists. Like the other adapters, we never create a lockfile the user has not
     // generated yet by running gleam.
-    for manifest_path in find_manifests(workspace_root) {
+    for manifest_path in find_manifests(&ScanIndex::build(workspace_root)) {
         let dir = match manifest_path.parent() {
             Some(dir) => dir,
             None => continue,
@@ -377,19 +393,14 @@ fn collect_dependencies(doc: &toml::Value, manifest_dir: &Path) -> Vec<ParsedDep
     deps
 }
 
-fn find_manifests(root: &Path) -> Vec<PathBuf> {
-    let mut out = Vec::new();
-    crate::adapters::scan::walk_package_dirs(root, &[], |dir, gitignore| {
-        let manifest = dir.join(GLEAM_MANIFEST);
+fn find_manifests(index: &ScanIndex) -> Vec<PathBuf> {
+    let mut out: Vec<PathBuf> = index
+        .dirs()
         // A `mix.exs` alongside is the mix_gleam interop: Mix owns the
         // package, so skip it to avoid double discovery.
-        if manifest.is_file()
-            && !dir.join("mix.exs").exists()
-            && !gitignore.is_ignored(dir, &manifest)
-        {
-            out.push(manifest);
-        }
-    });
+        .filter(|facts| facts.gleam_manifest && !facts.has_mix_exs)
+        .map(|facts| facts.dir.join(GLEAM_MANIFEST))
+        .collect();
     out.sort();
     out
 }

--- a/crates/sampo-core/src/adapters/hex/gleam/gleam_tests.rs
+++ b/crates/sampo-core/src/adapters/hex/gleam/gleam_tests.rs
@@ -79,6 +79,27 @@ fn discover_skips_build_output() {
 }
 
 #[test]
+fn discover_skips_gitignored_directories() {
+    let temp = tempfile::tempdir().unwrap();
+    write_file(
+        &temp.path().join("app/gleam.toml"),
+        "name = \"app\"\nversion = \"1.0.0\"\n",
+    );
+    write_file(&temp.path().join(".gitignore"), "generated/\n");
+    write_file(
+        &temp.path().join("generated/gleam.toml"),
+        "name = \"generated\"\nversion = \"9.9.9\"\n",
+    );
+
+    let names: Vec<String> = discover(temp.path())
+        .unwrap()
+        .into_iter()
+        .map(|p| p.name)
+        .collect();
+    assert_eq!(names, vec!["app"]);
+}
+
+#[test]
 fn discover_links_internal_path_dependency() {
     let temp = tempfile::tempdir().unwrap();
     write_file(

--- a/crates/sampo-core/src/adapters/hex/hex_tests.rs
+++ b/crates/sampo-core/src/adapters/hex/hex_tests.rs
@@ -503,6 +503,44 @@ mod rebar3_dispatch {
         assert!(applied.is_empty());
     }
 
+    /// Documents a current gap, not desired behaviour: an Elixir "poncho" repo
+    /// (sibling apps each with their own `mix.exs`, no root `mix.exs`) is invisible
+    /// to discovery.
+    #[test]
+    fn poncho_layout_is_invisible_to_discovery() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        for (app, version) in [("app_a", "0.1.0"), ("app_b", "0.2.0")] {
+            let dir = root.join(app);
+            fs::create_dir_all(&dir).unwrap();
+            fs::write(
+                dir.join("mix.exs"),
+                format!(
+                    "defmodule {app}.MixProject do\n  use Mix.Project\n  def project do\n    [app: :{app}, version: \"{version}\", deps: deps()]\n  end\n  defp deps, do: []\nend\n"
+                ),
+            )
+            .unwrap();
+        }
+
+        let packages = crate::workspace::discover_packages_at(root).unwrap();
+        assert!(
+            packages.is_empty(),
+            "expected poncho apps to be invisible, got {:?}",
+            packages.iter().map(|p| &p.name).collect::<Vec<_>>()
+        );
+
+        fs::write(root.join("rebar.config"), "{deps, []}.\n").unwrap();
+        write_erlang_app(&root.join("apps").join("erl_app"), "erl_app", "3.0.0");
+
+        let packages = crate::workspace::discover_packages_at(root).unwrap();
+        let names: Vec<&str> = packages.iter().map(|p| p.name.as_str()).collect();
+        assert_eq!(
+            names,
+            vec!["erl_app"],
+            "expected only the Erlang app; poncho Mix apps must remain undiscovered"
+        );
+    }
+
     #[test]
     fn discovers_mix_and_erlang_packages_together() {
         let temp = tempfile::tempdir().unwrap();

--- a/crates/sampo-core/src/adapters/hex/rebar3.rs
+++ b/crates/sampo-core/src/adapters/hex/rebar3.rs
@@ -123,6 +123,8 @@ pub(super) fn discover(root: &Path) -> std::result::Result<Vec<PackageInfo>, Wor
     Ok(packages)
 }
 
+/// Resolved without gitignore context, so it can pick an ignored `.app.src`
+/// that discovery skipped for a visible sibling.
 pub(super) fn manifest_path(package_dir: &Path) -> PathBuf {
     find_app_src(package_dir).unwrap_or_else(|| {
         // Unreachable for discovered packages (discovery found the file). Fall back to
@@ -554,11 +556,15 @@ fn is_app_src_file(path: &Path) -> bool {
 /// The single `src/*.app.src` under `package_dir`, if any (the first, sorted, when a
 /// directory unusually holds several).
 fn find_app_src(package_dir: &Path) -> Option<PathBuf> {
+    find_app_src_matching(package_dir, |_| true)
+}
+
+fn find_app_src_matching(package_dir: &Path, keep: impl Fn(&Path) -> bool) -> Option<PathBuf> {
     let mut candidates: Vec<PathBuf> = fs::read_dir(package_dir.join("src"))
         .ok()?
         .flatten()
         .map(|e| e.path())
-        .filter(|p| is_app_src_file(p))
+        .filter(|p| is_app_src_file(p) && keep(p))
         .collect();
     candidates.sort();
     candidates.into_iter().next()
@@ -571,8 +577,7 @@ fn find_app_srcs(root: &Path) -> Vec<PathBuf> {
         // ecosystems own the package, so skip to avoid double discovery.
         if !dir.join("mix.exs").exists()
             && !dir.join("gleam.toml").exists()
-            && let Some(app_src) = find_app_src(dir)
-            && !gitignore.is_ignored(dir, &app_src)
+            && let Some(app_src) = find_app_src_matching(dir, |p| !gitignore.is_ignored(dir, p))
         {
             out.push(app_src);
         }

--- a/crates/sampo-core/src/adapters/hex/rebar3.rs
+++ b/crates/sampo-core/src/adapters/hex/rebar3.rs
@@ -1,3 +1,4 @@
+use crate::adapters::scan::{LazyScan, ScanIndex};
 use crate::adapters::{format_command_display, has_flag};
 use crate::errors::{Result, SampoError, WorkspaceError};
 use crate::process::command;
@@ -12,13 +13,14 @@ use tree_sitter::{Language, Node, Parser, Tree};
 /// Holds `{deps, [...]}` at the application root; umbrella sub-apps may not carry a copy.
 const REBAR_CONFIG: &str = "rebar.config";
 
-/// `src/<name>.app.src` is the authoritative manifest (name + version), and the only
-/// file every app is guaranteed to have — unlike `rebar.config`, which umbrella members
-/// may omit.
-const APP_SRC_SUFFIX: &str = ".app.src";
-
+/// Test-only entry: production discovery always shares the pass's [`LazyScan`].
+#[cfg(test)]
 pub(super) fn can_discover(root: &Path) -> bool {
-    !find_app_srcs(root).is_empty()
+    can_discover_scanned(&LazyScan::new(root))
+}
+
+pub(super) fn can_discover_scanned(scan: &LazyScan) -> bool {
+    !find_app_srcs(scan.index()).is_empty()
 }
 
 /// Whether `package_dir` is an Erlang application root, i.e. it holds a `src/<name>.app.src`.
@@ -26,7 +28,15 @@ pub(super) fn has_app_src(package_dir: &Path) -> bool {
     find_app_src(package_dir).is_some()
 }
 
+/// Test-only entry: production discovery always shares the pass's [`LazyScan`].
+#[cfg(test)]
 pub(super) fn discover(root: &Path) -> std::result::Result<Vec<PackageInfo>, WorkspaceError> {
+    discover_scanned(&LazyScan::new(root))
+}
+
+pub(super) fn discover_scanned(
+    scan: &LazyScan,
+) -> std::result::Result<Vec<PackageInfo>, WorkspaceError> {
     struct Member {
         name: String,
         version: String,
@@ -34,10 +44,11 @@ pub(super) fn discover(root: &Path) -> std::result::Result<Vec<PackageInfo>, Wor
         applications: Vec<String>,
     }
 
+    let root = scan.root();
     let mut members: Vec<Member> = Vec::new();
     let mut member_names: BTreeSet<String> = BTreeSet::new();
 
-    for app_src in find_app_srcs(root) {
+    for app_src in find_app_srcs(scan.index()) {
         // `<app_root>/src/<name>.app.src` → the application root is the grandparent.
         let app_root = app_src
             .parent()
@@ -544,44 +555,20 @@ fn script_sibling_exists(app_src: &Path) -> bool {
         .unwrap_or(false)
 }
 
-fn is_app_src_file(path: &Path) -> bool {
-    // `<name>.app.src.script` ends in `.script`, so it is naturally excluded.
-    path.file_name()
-        .and_then(|n| n.to_str())
-        .map(|n| n.ends_with(APP_SRC_SUFFIX))
-        .unwrap_or(false)
-        && path.is_file()
-}
-
 /// The single `src/*.app.src` under `package_dir`, if any (the first, sorted, when a
 /// directory unusually holds several).
 fn find_app_src(package_dir: &Path) -> Option<PathBuf> {
-    find_app_src_matching(package_dir, |_| true)
+    crate::adapters::scan::find_app_src_matching(package_dir, |_| true)
 }
 
-fn find_app_src_matching(package_dir: &Path, keep: impl Fn(&Path) -> bool) -> Option<PathBuf> {
-    let mut candidates: Vec<PathBuf> = fs::read_dir(package_dir.join("src"))
-        .ok()?
-        .flatten()
-        .map(|e| e.path())
-        .filter(|p| is_app_src_file(p) && keep(p))
-        .collect();
-    candidates.sort();
-    candidates.into_iter().next()
-}
-
-fn find_app_srcs(root: &Path) -> Vec<PathBuf> {
-    let mut out = Vec::new();
-    crate::adapters::scan::walk_package_dirs(root, &[], |dir, gitignore| {
+fn find_app_srcs(index: &ScanIndex) -> Vec<PathBuf> {
+    let mut out: Vec<PathBuf> = index
+        .dirs()
         // Mix and Gleam projects may carry a generated `.app.src` too; those
         // ecosystems own the package, so skip to avoid double discovery.
-        if !dir.join("mix.exs").exists()
-            && !dir.join("gleam.toml").exists()
-            && let Some(app_src) = find_app_src_matching(dir, |p| !gitignore.is_ignored(dir, p))
-        {
-            out.push(app_src);
-        }
-    });
+        .filter(|facts| !facts.has_mix_exs && !facts.has_gleam_toml)
+        .filter_map(|facts| facts.app_src.clone())
+        .collect();
     out.sort();
     out
 }

--- a/crates/sampo-core/src/adapters/hex/rebar3.rs
+++ b/crates/sampo-core/src/adapters/hex/rebar3.rs
@@ -566,13 +566,13 @@ fn find_app_src(package_dir: &Path) -> Option<PathBuf> {
 
 fn find_app_srcs(root: &Path) -> Vec<PathBuf> {
     let mut out = Vec::new();
-    crate::adapters::scan::walk_package_dirs(root, &[], |dir| {
-        // A directory with `mix.exs` (Mix) or `gleam.toml` (Gleam) may also carry a generated
-        // `.app.src`; those ecosystems own their identity, so skip it here to avoid
-        // double-discovery.
+    crate::adapters::scan::walk_package_dirs(root, &[], |dir, gitignore| {
+        // Mix and Gleam projects may carry a generated `.app.src` too; those
+        // ecosystems own the package, so skip to avoid double discovery.
         if !dir.join("mix.exs").exists()
             && !dir.join("gleam.toml").exists()
             && let Some(app_src) = find_app_src(dir)
+            && !gitignore.is_ignored(dir, &app_src)
         {
             out.push(app_src);
         }

--- a/crates/sampo-core/src/adapters/hex/rebar3/rebar3_tests.rs
+++ b/crates/sampo-core/src/adapters/hex/rebar3/rebar3_tests.rs
@@ -201,6 +201,42 @@ fn discover_ignores_build_output_and_deps() {
 }
 
 #[test]
+fn discover_skips_gitignored_directories() {
+    let temp = tempfile::tempdir().unwrap();
+    write_file(
+        &temp.path().join("apps/a/src/a.app.src"),
+        &app_src("a", "1.0.0"),
+    );
+    write_file(&temp.path().join(".gitignore"), "generated/\n");
+    write_file(
+        &temp.path().join("apps/generated/src/gen.app.src"),
+        &app_src("gen", "9.9.9"),
+    );
+
+    let packages = discover(temp.path()).unwrap();
+    assert_eq!(packages.len(), 1);
+    assert_eq!(packages[0].name, "a");
+}
+
+#[test]
+fn discover_skips_app_when_src_is_gitignored() {
+    let temp = tempfile::tempdir().unwrap();
+    write_file(
+        &temp.path().join("apps/a/src/a.app.src"),
+        &app_src("a", "1.0.0"),
+    );
+    write_file(&temp.path().join("apps/b/.gitignore"), "src/\n");
+    write_file(
+        &temp.path().join("apps/b/src/b.app.src"),
+        &app_src("b", "9.9.9"),
+    );
+
+    let packages = discover(temp.path()).unwrap();
+    assert_eq!(packages.len(), 1);
+    assert_eq!(packages[0].name, "a");
+}
+
+#[test]
 fn discover_skips_mix_owned_directories() {
     let temp = tempfile::tempdir().unwrap();
     // A Mix project can carry a generated `.app.src`; Mix owns it, so rebar3 discovery

--- a/crates/sampo-core/src/adapters/hex/rebar3/rebar3_tests.rs
+++ b/crates/sampo-core/src/adapters/hex/rebar3/rebar3_tests.rs
@@ -544,3 +544,22 @@ fn discover_skips_directory_with_gleam_manifest() {
 
     assert!(discover(temp.path()).unwrap().is_empty());
 }
+
+#[test]
+fn discover_reads_sibling_when_first_app_src_is_gitignored() {
+    let temp = tempfile::tempdir().unwrap();
+    write_file(
+        &temp.path().join("src/aaa.app.src"),
+        &app_src("aaa", "1.0.0"),
+    );
+    write_file(
+        &temp.path().join("src/bbb.app.src"),
+        &app_src("bbb", "2.0.0"),
+    );
+    write_file(&temp.path().join(".gitignore"), "aaa.app.src\n");
+
+    let packages = discover(temp.path()).unwrap();
+    assert_eq!(packages.len(), 1);
+    assert_eq!(packages[0].name, "bbb");
+    assert_eq!(packages[0].version, "2.0.0");
+}

--- a/crates/sampo-core/src/adapters/pypi.rs
+++ b/crates/sampo-core/src/adapters/pypi.rs
@@ -1,3 +1,4 @@
+use crate::adapters::scan::LazyScan;
 use crate::errors::{Result, SampoError, WorkspaceError};
 use crate::types::PackageInfo;
 use reqwest::StatusCode;
@@ -34,11 +35,22 @@ impl PyPIAdapter {
         pip::can_discover(root)
     }
 
+    pub(super) fn can_discover_scanned(&self, scan: &LazyScan) -> bool {
+        pip::can_discover_scanned(scan)
+    }
+
     pub(super) fn discover(
         &self,
         root: &Path,
     ) -> std::result::Result<Vec<PackageInfo>, WorkspaceError> {
         pip::discover(root)
+    }
+
+    pub(super) fn discover_scanned(
+        &self,
+        scan: &LazyScan,
+    ) -> std::result::Result<Vec<PackageInfo>, WorkspaceError> {
+        pip::discover_scanned(scan)
     }
 
     pub(super) fn manifest_path(&self, package_dir: &Path) -> PathBuf {

--- a/crates/sampo-core/src/adapters/pypi/pip.rs
+++ b/crates/sampo-core/src/adapters/pypi/pip.rs
@@ -264,8 +264,9 @@ pub(super) fn validate_release_plan(
 
 fn scan_for_manifest_dirs(root: &Path) -> BTreeSet<PathBuf> {
     let mut dirs = BTreeSet::new();
-    crate::adapters::scan::walk_package_dirs(root, PYTHON_EXCLUDED_DIRS, |dir| {
-        if dir.join(PYPROJECT_MANIFEST).is_file() {
+    crate::adapters::scan::walk_package_dirs(root, PYTHON_EXCLUDED_DIRS, |dir, gitignore| {
+        let manifest = dir.join(PYPROJECT_MANIFEST);
+        if manifest.is_file() && !gitignore.is_ignored(dir, &manifest) {
             dirs.insert(normalize_path(dir));
         }
     });

--- a/crates/sampo-core/src/adapters/pypi/pip.rs
+++ b/crates/sampo-core/src/adapters/pypi/pip.rs
@@ -1,4 +1,5 @@
 use crate::adapters::format_command_display;
+use crate::adapters::scan::{LazyScan, ScanIndex};
 use crate::errors::{Result, SampoError, WorkspaceError};
 use crate::types::{PackageInfo, PackageKind};
 use std::collections::{BTreeMap, BTreeSet};
@@ -9,8 +10,8 @@ use toml_edit::{DocumentMut, Item, Value};
 
 const PYPROJECT_MANIFEST: &str = "pyproject.toml";
 
-/// Scan excludes beyond the shared set: virtual environments, caches, build
-/// output, and test fixtures.
+/// Names that exclude a whole subtree from pip's scan, beyond the shared set:
+/// virtual environments, caches, build output, and test fixtures.
 const PYTHON_EXCLUDED_DIRS: &[&str] = &[
     "venv",
     "env",
@@ -61,11 +62,22 @@ impl VersionOperator {
 }
 
 pub(super) fn can_discover(root: &Path) -> bool {
-    root.join(PYPROJECT_MANIFEST).exists() || !scan_for_manifest_dirs(root).is_empty()
+    can_discover_scanned(&LazyScan::new(root))
+}
+
+pub(super) fn can_discover_scanned(scan: &LazyScan) -> bool {
+    scan.root().join(PYPROJECT_MANIFEST).exists()
+        || !scan_for_manifest_dirs(scan.root(), scan.index()).is_empty()
 }
 
 pub(super) fn discover(root: &Path) -> std::result::Result<Vec<PackageInfo>, WorkspaceError> {
-    let (package_dirs, declared) = collect_package_dirs(root)?;
+    discover_scanned(&LazyScan::new(root))
+}
+
+pub(super) fn discover_scanned(
+    scan: &LazyScan,
+) -> std::result::Result<Vec<PackageInfo>, WorkspaceError> {
+    let (package_dirs, declared) = collect_package_dirs(scan)?;
 
     let mut manifests = Vec::new();
     // PEP 503: package names are case-insensitive and treat `.`, `-`, `_` as equivalent
@@ -189,8 +201,9 @@ pub(super) fn discover(root: &Path) -> std::result::Result<Vec<PackageInfo>, Wor
 /// it; only a repository without such a root is scanned for per-directory
 /// manifests.
 fn collect_package_dirs(
-    root: &Path,
+    scan: &LazyScan,
 ) -> std::result::Result<(BTreeSet<PathBuf>, bool), WorkspaceError> {
+    let root = scan.root();
     let manifest_path = root.join(PYPROJECT_MANIFEST);
     if manifest_path.exists() {
         let text = fs::read_to_string(&manifest_path).map_err(|e| {
@@ -227,14 +240,14 @@ fn collect_package_dirs(
                     "Warning: {} is invalid TOML: {err}",
                     manifest_path.display()
                 );
-                let mut package_dirs = scan_for_manifest_dirs(root);
+                let mut package_dirs = scan_for_manifest_dirs(root, scan.index());
                 // Warned just above; drop the root so it is not reported twice.
                 package_dirs.remove(&normalize_path(root));
                 return Ok((package_dirs, false));
             }
         }
     }
-    Ok((scan_for_manifest_dirs(root), false))
+    Ok((scan_for_manifest_dirs(root, scan.index()), false))
 }
 
 /// Fail before any manifest is written when a planned package cannot take its
@@ -262,15 +275,24 @@ pub(super) fn validate_release_plan(
     Ok(())
 }
 
-fn scan_for_manifest_dirs(root: &Path) -> BTreeSet<PathBuf> {
-    let mut dirs = BTreeSet::new();
-    crate::adapters::scan::walk_package_dirs(root, PYTHON_EXCLUDED_DIRS, |dir, gitignore| {
-        let manifest = dir.join(PYPROJECT_MANIFEST);
-        if manifest.is_file() && !gitignore.is_ignored(dir, &manifest) {
-            dirs.insert(normalize_path(dir));
-        }
-    });
-    dirs
+fn scan_for_manifest_dirs(root: &Path, index: &ScanIndex) -> BTreeSet<PathBuf> {
+    index
+        .dirs()
+        .filter(|facts| facts.pyproject && !has_python_excluded_component(root, &facts.dir))
+        .map(|facts| normalize_path(&facts.dir))
+        .collect()
+}
+
+fn has_python_excluded_component(root: &Path, dir: &Path) -> bool {
+    let Ok(rel) = dir.strip_prefix(root) else {
+        return false;
+    };
+    rel.components().any(|component| match component {
+        Component::Normal(name) => name
+            .to_str()
+            .is_some_and(|name| PYTHON_EXCLUDED_DIRS.contains(&name)),
+        _ => false,
+    })
 }
 
 pub(super) fn manifest_path(package_dir: &Path) -> PathBuf {
@@ -422,7 +444,7 @@ pub(super) fn publish(manifest_path: &Path, dry_run: bool, extra_args: &[String]
 /// shares a single root uv.lock; scanned packages each own one. Never
 /// creates a lockfile the user has not generated.
 fn uv_lock_dirs(workspace_root: &Path) -> Result<Vec<PathBuf>> {
-    let (package_dirs, declared) = collect_package_dirs(workspace_root)
+    let (package_dirs, declared) = collect_package_dirs(&LazyScan::new(workspace_root))
         .map_err(|err| SampoError::Release(format!("cannot regenerate lockfile; {err}")))?;
 
     let candidates: Vec<PathBuf> = if declared {

--- a/crates/sampo-core/src/adapters/pypi/pip/pip_tests.rs
+++ b/crates/sampo-core/src/adapters/pypi/pip/pip_tests.rs
@@ -187,6 +187,52 @@ fn discover_scan_skips_virtualenvs_caches_and_fixtures() {
 }
 
 #[test]
+fn discover_scan_skips_manifests_nested_under_excluded_dirs() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    write_file(
+        &root.join("pkg/pyproject.toml"),
+        "[project]\nname = \"pkg\"\nversion = \"0.1.0\"\n",
+    );
+    write_file(
+        &root.join("venv/sub/vendored/pyproject.toml"),
+        "[project]\nname = \"vendored\"\nversion = \"9.9.9\"\n",
+    );
+
+    let packages = discover(root).unwrap();
+    let names: Vec<_> = packages.iter().map(|p| p.name.as_str()).collect();
+    assert_eq!(names, vec!["pkg"]);
+}
+
+#[test]
+fn discover_uv_workspace_members_deeper_than_scan_depth() {
+    // Declared members resolve through glob/path expansion, never through the
+    // depth-bounded scan.
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    write_file(
+        &root.join("pyproject.toml"),
+        r#"
+[project]
+name = "root"
+version = "1.0.0"
+
+[tool.uv.workspace]
+members = ["a/b/c/d/e/pkg-deep"]
+"#,
+    );
+    write_file(
+        &root.join("a/b/c/d/e/pkg-deep/pyproject.toml"),
+        "[project]\nname = \"pkg-deep\"\nversion = \"0.1.0\"\n",
+    );
+
+    let packages = discover(root).unwrap();
+    let names: Vec<&str> = packages.iter().map(|p| p.name.as_str()).collect();
+    assert!(names.contains(&"root"));
+    assert!(names.contains(&"pkg-deep"));
+}
+
+#[test]
 fn discover_scan_honours_gitignore() {
     let temp = tempfile::tempdir().unwrap();
     let root = temp.path();

--- a/crates/sampo-core/src/adapters/pypi/pip/pip_tests.rs
+++ b/crates/sampo-core/src/adapters/pypi/pip/pip_tests.rs
@@ -187,6 +187,31 @@ fn discover_scan_skips_virtualenvs_caches_and_fixtures() {
 }
 
 #[test]
+fn discover_scan_honours_gitignore() {
+    let temp = tempfile::tempdir().unwrap();
+    let root = temp.path();
+    write_file(
+        &root.join("pkg_a/pyproject.toml"),
+        "[project]\nname = \"pkg-a\"\nversion = \"0.1.0\"\n",
+    );
+    write_file(&root.join(".gitignore"), "vendored/\n");
+    write_file(
+        &root.join("vendored/pyproject.toml"),
+        "[project]\nname = \"vendored-pkg\"\nversion = \"9.9.9\"\n",
+    );
+    // The catch-all `.gitignore` is the virtual-environment shape.
+    write_file(&root.join("myenv/.gitignore"), "*\n");
+    write_file(
+        &root.join("myenv/pyproject.toml"),
+        "[project]\nname = \"env-pkg\"\nversion = \"9.9.9\"\n",
+    );
+
+    let packages = discover(root).unwrap();
+    let names: Vec<_> = packages.iter().map(|p| p.name.as_str()).collect();
+    assert_eq!(names, vec!["pkg-a"]);
+}
+
+#[test]
 fn discover_scan_ignores_tool_config_only_manifests() {
     let temp = tempfile::tempdir().unwrap();
     let root = temp.path();

--- a/crates/sampo-core/src/adapters/scan.rs
+++ b/crates/sampo-core/src/adapters/scan.rs
@@ -9,8 +9,9 @@
 
 use ignore::Match;
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
+use std::cell::OnceCell;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 /// Keeps the scan cheap on unrelated repos and out of deep vendored trees.
 pub(crate) const MAX_SCAN_DEPTH: usize = 4;
@@ -92,24 +93,19 @@ impl GitignoreChain {
 
 /// Visit `root` and its subdirectories up to [`MAX_SCAN_DEPTH`] levels deep,
 /// calling `visit` once per directory with the `.gitignore` rules in force
-/// there. Hidden directories, build/dependency output, `extra_excluded`
-/// names, and gitignored directories are skipped; symlinked directories are
-/// never followed. Callers must check candidate manifests against the chain:
-/// a directory's own `.gitignore` can exclude its files (how virtual
-/// environments self-exclude) while the directory itself is still visited.
-pub(crate) fn walk_package_dirs<F: FnMut(&Path, &GitignoreChain)>(
-    root: &Path,
-    extra_excluded: &[&str],
-    mut visit: F,
-) {
+/// there. Hidden directories, build/dependency output, and gitignored
+/// directories are skipped; symlinked directories are never followed.
+/// Callers must check candidate manifests against the chain: a directory's
+/// own `.gitignore` can exclude its files (how virtual environments
+/// self-exclude) while the directory itself is still visited.
+pub(crate) fn walk_package_dirs<F: FnMut(&Path, &GitignoreChain)>(root: &Path, mut visit: F) {
     let mut chain = GitignoreChain::default();
-    walk(root, 0, extra_excluded, &mut chain, &mut visit);
+    walk(root, 0, &mut chain, &mut visit);
 }
 
 fn walk<F: FnMut(&Path, &GitignoreChain)>(
     dir: &Path,
     depth: usize,
-    extra_excluded: &[&str],
     chain: &mut GitignoreChain,
     visit: &mut F,
 ) {
@@ -124,10 +120,10 @@ fn walk<F: FnMut(&Path, &GitignoreChain)>(
             if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
                 continue;
             }
-            if is_excluded_dir(&path, extra_excluded) || chain.is_ignored_dir(&path) {
+            if is_excluded_dir(&path) || chain.is_ignored_dir(&path) {
                 continue;
             }
-            walk(&path, depth + 1, extra_excluded, chain, visit);
+            walk(&path, depth + 1, chain, visit);
         }
     }
     if pushed {
@@ -135,15 +131,121 @@ fn walk<F: FnMut(&Path, &GitignoreChain)>(
     }
 }
 
-fn is_excluded_dir(path: &Path, extra_excluded: &[&str]) -> bool {
+fn is_excluded_dir(path: &Path) -> bool {
     match path.file_name().and_then(|n| n.to_str()) {
-        Some(name) => {
-            name.starts_with('.')
-                || EXCLUDED_DIR_NAMES.contains(&name)
-                || extra_excluded.contains(&name)
-        }
+        Some(name) => name.starts_with('.') || EXCLUDED_DIR_NAMES.contains(&name),
         None => true,
     }
+}
+
+/// What one visited directory holds, gitignore rules already applied.
+/// Ownership vetoes (a `mix.exs` silencing a Gleam manifest, …) are left to
+/// each consumer: the vetoes differ per ecosystem, the facts do not.
+pub(crate) struct DirFacts {
+    pub(crate) dir: PathBuf,
+    /// `mix.exs` exists — even gitignored, it still marks Mix ownership.
+    pub(crate) has_mix_exs: bool,
+    /// `gleam.toml` exists in any form; the veto rebar3 applies
+    /// (`Path::exists`, not gitignore-aware).
+    pub(crate) has_gleam_toml: bool,
+    /// `gleam.toml` is a real file and not gitignored: a Gleam candidate.
+    pub(crate) gleam_manifest: bool,
+    /// First non-gitignored `src/*.app.src` (sorted), one level below `dir`.
+    pub(crate) app_src: Option<PathBuf>,
+    /// `pyproject.toml` is a real file and not gitignored.
+    pub(crate) pyproject: bool,
+}
+
+impl DirFacts {
+    fn collect(dir: &Path, chain: &GitignoreChain) -> Self {
+        let gleam_toml = dir.join("gleam.toml");
+        let gleam_meta = fs::metadata(&gleam_toml);
+        let gleam_is_file = gleam_meta.as_ref().map(|m| m.is_file()).unwrap_or(false);
+        let pyproject = dir.join("pyproject.toml");
+        DirFacts {
+            has_mix_exs: dir.join("mix.exs").exists(),
+            has_gleam_toml: gleam_meta.is_ok(),
+            gleam_manifest: gleam_is_file && !chain.is_ignored(dir, &gleam_toml),
+            app_src: find_app_src_matching(dir, |path| !chain.is_ignored(dir, path)),
+            pyproject: pyproject.is_file() && !chain.is_ignored(dir, &pyproject),
+            dir: dir.to_path_buf(),
+        }
+    }
+}
+
+/// The facts of every directory one bounded walk visits, shared by all
+/// scanning ecosystems. Python's extra excluded names are not pruned here:
+/// pip filters them out afterwards, so the walk stays common.
+pub(crate) struct ScanIndex {
+    dirs: Vec<DirFacts>,
+}
+
+impl ScanIndex {
+    pub(crate) fn build(root: &Path) -> Self {
+        let mut dirs = Vec::new();
+        walk_package_dirs(root, |dir, chain| {
+            dirs.push(DirFacts::collect(dir, chain));
+        });
+        ScanIndex { dirs }
+    }
+
+    pub(crate) fn dirs(&self) -> impl Iterator<Item = &DirFacts> {
+        self.dirs.iter()
+    }
+}
+
+/// A [`ScanIndex`] built on first use and shared for the rest of a discovery
+/// pass: the tree is walked at most once, and callers that never consult the
+/// index skip the walk entirely.
+pub(crate) struct LazyScan<'a> {
+    root: &'a Path,
+    index: OnceCell<ScanIndex>,
+}
+
+impl<'a> LazyScan<'a> {
+    pub(crate) fn new(root: &'a Path) -> Self {
+        LazyScan {
+            root,
+            index: OnceCell::new(),
+        }
+    }
+
+    pub(crate) fn root(&self) -> &'a Path {
+        self.root
+    }
+
+    pub(crate) fn index(&self) -> &ScanIndex {
+        self.index.get_or_init(|| ScanIndex::build(self.root))
+    }
+}
+
+/// `src/<name>.app.src` is the authoritative rebar3 manifest; a
+/// `<name>.app.src.script` sibling ends in `.script`, so it is naturally
+/// excluded.
+const APP_SRC_SUFFIX: &str = ".app.src";
+
+fn is_app_src_file(path: &Path) -> bool {
+    path.file_name()
+        .and_then(|n| n.to_str())
+        .map(|n| n.ends_with(APP_SRC_SUFFIX))
+        .unwrap_or(false)
+        && path.is_file()
+}
+
+/// The first `src/*.app.src` under `package_dir` satisfying `keep` (sorted,
+/// when a directory unusually holds several).
+pub(crate) fn find_app_src_matching(
+    package_dir: &Path,
+    keep: impl Fn(&Path) -> bool,
+) -> Option<PathBuf> {
+    let mut candidates: Vec<PathBuf> = fs::read_dir(package_dir.join("src"))
+        .ok()?
+        .flatten()
+        .map(|e| e.path())
+        .filter(|p| is_app_src_file(p) && keep(p))
+        .collect();
+    candidates.sort();
+    candidates.into_iter().next()
 }
 
 #[cfg(test)]
@@ -153,9 +255,9 @@ mod tests {
     use std::fs;
     use std::path::PathBuf;
 
-    fn visited_dirs(root: &Path, extra_excluded: &[&str]) -> BTreeSet<PathBuf> {
+    fn visited_dirs(root: &Path) -> BTreeSet<PathBuf> {
         let mut out = BTreeSet::new();
-        walk_package_dirs(root, extra_excluded, |dir, _| {
+        walk_package_dirs(root, |dir, _| {
             out.insert(dir.to_path_buf());
         });
         out
@@ -169,7 +271,7 @@ mod tests {
         let beyond_limit = at_limit.join("e");
         fs::create_dir_all(&beyond_limit).unwrap();
 
-        let visited = visited_dirs(root, &[]);
+        let visited = visited_dirs(root);
 
         assert!(visited.contains(root));
         assert!(visited.contains(&at_limit));
@@ -177,18 +279,18 @@ mod tests {
     }
 
     #[test]
-    fn skips_hidden_shared_and_extra_excluded_dirs() {
+    fn skips_hidden_and_shared_excluded_dirs() {
         let temp = tempfile::tempdir().unwrap();
         let root = temp.path();
-        for dir in [".git", "node_modules", "target", "venv", "kept"] {
+        for dir in [".git", "node_modules", "target", "kept"] {
             fs::create_dir_all(root.join(dir).join("inner")).unwrap();
         }
 
-        let visited = visited_dirs(root, &["venv"]);
+        let visited = visited_dirs(root);
 
         assert!(visited.contains(&root.join("kept")));
         assert!(visited.contains(&root.join("kept/inner")));
-        for dir in [".git", "node_modules", "target", "venv"] {
+        for dir in [".git", "node_modules", "target"] {
             assert!(
                 !visited.contains(&root.join(dir)),
                 "{dir} should be skipped"
@@ -204,7 +306,7 @@ mod tests {
         fs::create_dir_all(root.join("real/inner")).unwrap();
         std::os::unix::fs::symlink(root.join("real"), root.join("linked")).unwrap();
 
-        let visited = visited_dirs(root, &[]);
+        let visited = visited_dirs(root);
 
         assert!(visited.contains(&root.join("real")));
         assert!(!visited.contains(&root.join("linked")));
@@ -218,7 +320,7 @@ mod tests {
         fs::create_dir_all(root.join("kept")).unwrap();
         fs::write(root.join(".gitignore"), "vendored/\n").unwrap();
 
-        let visited = visited_dirs(root, &[]);
+        let visited = visited_dirs(root);
 
         assert!(visited.contains(&root.join("kept")));
         assert!(!visited.contains(&root.join("vendored")));
@@ -233,7 +335,7 @@ mod tests {
         fs::create_dir_all(root.join("sub/gen")).unwrap();
         fs::write(root.join("sub/.gitignore"), "gen/\n").unwrap();
 
-        let visited = visited_dirs(root, &[]);
+        let visited = visited_dirs(root);
 
         assert!(visited.contains(&root.join("gen")));
         assert!(!visited.contains(&root.join("sub/gen")));
@@ -248,7 +350,7 @@ mod tests {
         fs::write(root.join(".gitignore"), "keep/\n").unwrap();
         fs::write(root.join("sub/.gitignore"), "!keep/\n").unwrap();
 
-        let visited = visited_dirs(root, &[]);
+        let visited = visited_dirs(root);
 
         assert!(!visited.contains(&root.join("keep")));
         assert!(visited.contains(&root.join("sub/keep")));
@@ -267,7 +369,7 @@ mod tests {
         fs::write(root.join("pkg/pyproject.toml"), "").unwrap();
 
         let mut with_manifest = BTreeSet::new();
-        walk_package_dirs(root, &[], |dir, chain| {
+        walk_package_dirs(root, |dir, chain| {
             let manifest = dir.join("pyproject.toml");
             if manifest.is_file() && !chain.is_ignored(dir, &manifest) {
                 with_manifest.insert(dir.to_path_buf());
@@ -275,7 +377,7 @@ mod tests {
         });
 
         assert!(with_manifest.contains(&root.join("pkg")));
-        assert!(visited_dirs(root, &[]).contains(&root.join("myenv")));
+        assert!(visited_dirs(root).contains(&root.join("myenv")));
         assert!(!with_manifest.contains(&root.join("myenv")));
     }
 
@@ -290,7 +392,7 @@ mod tests {
         fs::write(root.join("app/src/thing.app.src"), "").unwrap();
 
         let mut ignored = None;
-        walk_package_dirs(root, &[], |dir, chain| {
+        walk_package_dirs(root, |dir, chain| {
             if dir.ends_with("app") {
                 ignored = Some(chain.is_ignored(dir, &dir.join("src/thing.app.src")));
             }
@@ -311,14 +413,14 @@ mod tests {
         fs::write(root.join("sub/config/pyproject.toml"), "").unwrap();
 
         let mut with_manifest = BTreeSet::new();
-        walk_package_dirs(root, &[], |dir, chain| {
+        walk_package_dirs(root, |dir, chain| {
             let manifest = dir.join("pyproject.toml");
             if manifest.is_file() && !chain.is_ignored(dir, &manifest) {
                 with_manifest.insert(dir.to_path_buf());
             }
         });
 
-        assert!(visited_dirs(root, &[]).contains(&root.join("sub/config")));
+        assert!(visited_dirs(root).contains(&root.join("sub/config")));
         assert!(!with_manifest.contains(&root.join("sub/config")));
     }
 }

--- a/crates/sampo-core/src/adapters/scan.rs
+++ b/crates/sampo-core/src/adapters/scan.rs
@@ -1,48 +1,137 @@
 //! Bounded directory scan shared by ecosystems without a native workspace
 //! declaration: there a monorepo is just several directories each carrying
 //! their own manifest, so packages are found by walking the tree.
+//!
+//! `.gitignore` files met along the walk are honoured. Only files inside the
+//! walked tree are read — never the global gitignore, `.git/info/exclude`, or
+//! anything above `root` — so local and CI scans agree and no git repository
+//! is required.
 
+use ignore::Match;
+use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use std::fs;
 use std::path::Path;
 
-/// Bounds the scan so it stays cheap on unrelated repos and never wanders
-/// into deep vendored trees.
+/// Keeps the scan cheap on unrelated repos and out of deep vendored trees.
 pub(crate) const MAX_SCAN_DEPTH: usize = 4;
 
 /// Build output and fetched dependencies skipped for every ecosystem; hidden
 /// directories are skipped by the walk itself.
 const EXCLUDED_DIR_NAMES: &[&str] = &["build", "_build", "deps", "node_modules", "target"];
 
+/// The `.gitignore` rules gathered between the scan root and the visited
+/// directory, deeper files taking precedence as in git.
+///
+/// Matching is by pattern only: a manifest force-added to git (`git add -f`)
+/// inside an ignored directory is still skipped.
+#[derive(Default)]
+pub(crate) struct GitignoreChain {
+    matchers: Vec<Gitignore>,
+}
+
+impl GitignoreChain {
+    /// Whether the scan should skip the file at `path`, which must live below
+    /// `base`, the visited directory. As in git, each level between `base`
+    /// and the file resolves separately: an ignored ancestor hides the file;
+    /// a whitelisted ancestor settles only itself, never the file.
+    /// `.gitignore` files deeper than `base` are not consulted.
+    pub(crate) fn is_ignored(&self, base: &Path, path: &Path) -> bool {
+        let Ok(rel) = path.strip_prefix(base) else {
+            debug_assert!(false, "{path:?} must live below the visited {base:?}");
+            return false;
+        };
+        let mut level_path = base.to_path_buf();
+        let mut components = rel.components().peekable();
+        while let Some(component) = components.next() {
+            level_path.push(component);
+            let is_dir = components.peek().is_some();
+            if self.level(&level_path, is_dir) == Some(true) {
+                return true;
+            }
+        }
+        false
+    }
+
+    fn level(&self, path: &Path, is_dir: bool) -> Option<bool> {
+        for matcher in self.matchers.iter().rev() {
+            match matcher.matched(path, is_dir) {
+                Match::Ignore(_) => return Some(true),
+                Match::Whitelist(_) => return Some(false),
+                Match::None => {}
+            }
+        }
+        None
+    }
+
+    fn is_ignored_dir(&self, path: &Path) -> bool {
+        self.level(path, true) == Some(true)
+    }
+
+    /// Load `dir/.gitignore` if present; reports whether a matcher was pushed.
+    fn push(&mut self, dir: &Path) -> bool {
+        let file = dir.join(".gitignore");
+        if !file.is_file() {
+            return false;
+        }
+        let mut builder = GitignoreBuilder::new(dir);
+        // Unparseable lines are dropped by the builder; valid ones still apply.
+        builder.add(&file);
+        match builder.build() {
+            Ok(matcher) if !matcher.is_empty() => {
+                self.matchers.push(matcher);
+                true
+            }
+            _ => false,
+        }
+    }
+
+    fn pop(&mut self) {
+        self.matchers.pop();
+    }
+}
+
 /// Visit `root` and its subdirectories up to [`MAX_SCAN_DEPTH`] levels deep,
-/// calling `visit` once per directory. Hidden directories, common
-/// build/dependency output, and `extra_excluded` names are skipped, and
-/// symlinked directories are never followed, so vendored manifests are not
-/// mistaken for workspace members.
-pub(crate) fn walk_package_dirs<F: FnMut(&Path)>(
+/// calling `visit` once per directory with the `.gitignore` rules in force
+/// there. Hidden directories, build/dependency output, `extra_excluded`
+/// names, and gitignored directories are skipped; symlinked directories are
+/// never followed. Callers must check candidate manifests against the chain:
+/// a directory's own `.gitignore` can exclude its files (how virtual
+/// environments self-exclude) while the directory itself is still visited.
+pub(crate) fn walk_package_dirs<F: FnMut(&Path, &GitignoreChain)>(
     root: &Path,
     extra_excluded: &[&str],
     mut visit: F,
 ) {
-    walk(root, 0, extra_excluded, &mut visit);
+    let mut chain = GitignoreChain::default();
+    walk(root, 0, extra_excluded, &mut chain, &mut visit);
 }
 
-fn walk<F: FnMut(&Path)>(dir: &Path, depth: usize, extra_excluded: &[&str], visit: &mut F) {
+fn walk<F: FnMut(&Path, &GitignoreChain)>(
+    dir: &Path,
+    depth: usize,
+    extra_excluded: &[&str],
+    chain: &mut GitignoreChain,
+    visit: &mut F,
+) {
     if depth > MAX_SCAN_DEPTH {
         return;
     }
-    visit(dir);
-    let Ok(entries) = fs::read_dir(dir) else {
-        return;
-    };
-    for entry in entries.flatten() {
-        let path = entry.path();
-        if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
-            continue;
+    let pushed = chain.push(dir);
+    visit(dir, chain);
+    if let Ok(entries) = fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !entry.file_type().map(|t| t.is_dir()).unwrap_or(false) {
+                continue;
+            }
+            if is_excluded_dir(&path, extra_excluded) || chain.is_ignored_dir(&path) {
+                continue;
+            }
+            walk(&path, depth + 1, extra_excluded, chain, visit);
         }
-        if is_excluded_dir(&path, extra_excluded) {
-            continue;
-        }
-        walk(&path, depth + 1, extra_excluded, visit);
+    }
+    if pushed {
+        chain.pop();
     }
 }
 
@@ -66,7 +155,7 @@ mod tests {
 
     fn visited_dirs(root: &Path, extra_excluded: &[&str]) -> BTreeSet<PathBuf> {
         let mut out = BTreeSet::new();
-        walk_package_dirs(root, extra_excluded, |dir| {
+        walk_package_dirs(root, extra_excluded, |dir, _| {
             out.insert(dir.to_path_buf());
         });
         out
@@ -119,5 +208,117 @@ mod tests {
 
         assert!(visited.contains(&root.join("real")));
         assert!(!visited.contains(&root.join("linked")));
+    }
+
+    #[test]
+    fn gitignore_excludes_matching_dirs() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        fs::create_dir_all(root.join("vendored/inner")).unwrap();
+        fs::create_dir_all(root.join("kept")).unwrap();
+        fs::write(root.join(".gitignore"), "vendored/\n").unwrap();
+
+        let visited = visited_dirs(root, &[]);
+
+        assert!(visited.contains(&root.join("kept")));
+        assert!(!visited.contains(&root.join("vendored")));
+        assert!(!visited.contains(&root.join("vendored/inner")));
+    }
+
+    #[test]
+    fn nested_gitignore_applies_to_its_subtree_only() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        fs::create_dir_all(root.join("gen")).unwrap();
+        fs::create_dir_all(root.join("sub/gen")).unwrap();
+        fs::write(root.join("sub/.gitignore"), "gen/\n").unwrap();
+
+        let visited = visited_dirs(root, &[]);
+
+        assert!(visited.contains(&root.join("gen")));
+        assert!(!visited.contains(&root.join("sub/gen")));
+    }
+
+    #[test]
+    fn deeper_gitignore_negation_overrides_shallower_rule() {
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        fs::create_dir_all(root.join("keep")).unwrap();
+        fs::create_dir_all(root.join("sub/keep")).unwrap();
+        fs::write(root.join(".gitignore"), "keep/\n").unwrap();
+        fs::write(root.join("sub/.gitignore"), "!keep/\n").unwrap();
+
+        let visited = visited_dirs(root, &[]);
+
+        assert!(!visited.contains(&root.join("keep")));
+        assert!(visited.contains(&root.join("sub/keep")));
+    }
+
+    #[test]
+    fn chain_excludes_files_ignored_by_their_own_dir() {
+        // The virtual-environment shape: a catch-all `.gitignore` in the
+        // directory itself.
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        fs::create_dir_all(root.join("myenv")).unwrap();
+        fs::create_dir_all(root.join("pkg")).unwrap();
+        fs::write(root.join("myenv/.gitignore"), "*\n").unwrap();
+        fs::write(root.join("myenv/pyproject.toml"), "").unwrap();
+        fs::write(root.join("pkg/pyproject.toml"), "").unwrap();
+
+        let mut with_manifest = BTreeSet::new();
+        walk_package_dirs(root, &[], |dir, chain| {
+            let manifest = dir.join("pyproject.toml");
+            if manifest.is_file() && !chain.is_ignored(dir, &manifest) {
+                with_manifest.insert(dir.to_path_buf());
+            }
+        });
+
+        assert!(with_manifest.contains(&root.join("pkg")));
+        assert!(visited_dirs(root, &[]).contains(&root.join("myenv")));
+        assert!(!with_manifest.contains(&root.join("myenv")));
+    }
+
+    #[test]
+    fn ignored_intermediate_level_hides_deeper_files() {
+        // The rebar3 shape: the candidate sits a level below the visited
+        // directory, beyond the walk's pruning.
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        fs::create_dir_all(root.join("app/src")).unwrap();
+        fs::write(root.join("app/.gitignore"), "src/\n").unwrap();
+        fs::write(root.join("app/src/thing.app.src"), "").unwrap();
+
+        let mut ignored = None;
+        walk_package_dirs(root, &[], |dir, chain| {
+            if dir.ends_with("app") {
+                ignored = Some(chain.is_ignored(dir, &dir.join("src/thing.app.src")));
+            }
+        });
+
+        assert_eq!(ignored, Some(true));
+    }
+
+    #[test]
+    fn whitelisted_ancestor_dir_does_not_unignore_file() {
+        // Matches git: `!config/` re-includes only the directory, never its
+        // files — `git check-ignore -v` still reports `.gitignore:1:*.toml`.
+        let temp = tempfile::tempdir().unwrap();
+        let root = temp.path();
+        fs::create_dir_all(root.join("sub/config")).unwrap();
+        fs::write(root.join(".gitignore"), "*.toml\n").unwrap();
+        fs::write(root.join("sub/.gitignore"), "!config/\n").unwrap();
+        fs::write(root.join("sub/config/pyproject.toml"), "").unwrap();
+
+        let mut with_manifest = BTreeSet::new();
+        walk_package_dirs(root, &[], |dir, chain| {
+            let manifest = dir.join("pyproject.toml");
+            if manifest.is_file() && !chain.is_ignored(dir, &manifest) {
+                with_manifest.insert(dir.to_path_buf());
+            }
+        });
+
+        assert!(visited_dirs(root, &[]).contains(&root.join("sub/config")));
+        assert!(!with_manifest.contains(&root.join("sub/config")));
     }
 }

--- a/crates/sampo-core/src/workspace.rs
+++ b/crates/sampo-core/src/workspace.rs
@@ -1,4 +1,5 @@
 use crate::adapters::PackageAdapter;
+use crate::adapters::scan::LazyScan;
 use crate::errors::WorkspaceError;
 use crate::types::Workspace;
 use std::path::{Path, PathBuf};
@@ -57,9 +58,10 @@ pub fn discover_workspace(start_dir: &Path) -> Result<Workspace> {
 pub fn discover_packages_at(root: &Path) -> Result<Vec<crate::types::PackageInfo>> {
     let mut all_members = Vec::new();
 
+    let scan = LazyScan::new(root);
     for adapter in PackageAdapter::all() {
-        if adapter.can_discover(root) {
-            let packages = adapter.discover(root)?;
+        if adapter.can_discover_scanned(&scan) {
+            let packages = adapter.discover_scanned(&scan)?;
             all_members.extend(packages);
         }
     }


### PR DESCRIPTION
## What has changed?

Fixes #314. Package scanning (Python, Gleam, and Erlang) now honours the `.gitignore` files met along the walk, so repositories drive exclusions for every scanning ecosystem and virtual environments self-exclude through the catch-all `.gitignore` written by uv and `python -m venv` (3.13+).

The new dependency is ripgrep's `ignore` crate (its `gitignore` matcher only, the walk stays ours). Only `.gitignore` files inside the scanned tree are read, never your personal global gitignore (`core.excludesFile`) or `.git/info/exclude`, so local and CI checkouts agree and no git repository is required. Matching is by pattern only, like ripgrep: a tracked but gitignored manifest is still skipped, and a `.gitignore` deeper than the visited directory is not read.

Discovery now walks the repository once per pass: one shared, lazily-built scan serves the three scanning ecosystems.

## How is it tested?

Walker unit tests (exclusions, nesting, negation precedence checked against git's own resolution) plus discovery tests for each scanning ecosystem, including the venv catch-all shape.

## How is it documented?

The changeset, plus the bounds noted in `adapters/scan.rs`'s docs.
